### PR TITLE
Refactor/#6 [Board] 리소스 소유자 검증 AOP 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
 	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.3'
 	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/src/main/java/com/web/SearchWeb/aop/OwnerCheck.java
+++ b/src/main/java/com/web/SearchWeb/aop/OwnerCheck.java
@@ -1,0 +1,13 @@
+package com.web.SearchWeb.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface OwnerCheck {
+    String idParam();
+    String service();
+}

--- a/src/main/java/com/web/SearchWeb/aop/OwnerCheck.java
+++ b/src/main/java/com/web/SearchWeb/aop/OwnerCheck.java
@@ -5,6 +5,10 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * 리소스 소유자 검증을 위한 AOP 어노테이션
+ *  -메서드 실행 전에 현재 사용자가 해당 리소스의 소유자인지 확인
+ */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface OwnerCheck {

--- a/src/main/java/com/web/SearchWeb/aop/OwnerCheckAspect.java
+++ b/src/main/java/com/web/SearchWeb/aop/OwnerCheckAspect.java
@@ -1,0 +1,113 @@
+package com.web.SearchWeb.aop;
+
+import com.web.SearchWeb.board.service.BoardService;
+import com.web.SearchWeb.comment.service.CommentService;
+import com.web.SearchWeb.member.dto.CustomOAuth2User;
+import com.web.SearchWeb.member.dto.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+@Aspect
+@Slf4j(topic = "[OwnerCheckAspect]")
+@Component
+@RequiredArgsConstructor
+public class OwnerCheckAspect {
+
+    private final BoardService boardService;
+    private final CommentService commentService;
+
+    /**
+     * @OwnerCheck 어노테이션이 붙은 메서드 실행 전,
+     * 요청한 사용자가 해당 리소스의 소유자인지 검사
+     */
+    @Before("@annotation(ownerCheck)")
+    public void validateOwner(JoinPoint joinPoint, OwnerCheck ownerCheck) {
+        // 접근 검증 대상 리소스의 ID 추출
+        Integer targetId = extractTargetIdFromParams(joinPoint, ownerCheck.idParam());
+
+        // 현재 로그인한 사용자의 memberId 추출
+        Authentication auth = validateAuthenticatedUser();
+        Integer currentUserId = extractMemberId(auth);
+
+        // 서비스 이름에 따라 리소스 작성자 memberId 조회
+        Integer ownerId = findOwnerIdByServiceName(ownerCheck.service(), targetId);
+
+        // 현재 사용자와 리소스 소유자 검증
+        if (!Objects.equals(currentUserId, ownerId)) {
+            log.warn("접근 거부: 사용자 ID {} ≠ 소유자 ID {}", currentUserId, ownerId);
+            throw new SecurityException("소유자만 접근 가능합니다.");
+        }
+    }
+
+
+
+
+    /**
+     * 접근 검증 대상이 되는 리소스의 ID를 파라미터 이름(idParam)을 통해 찾아 Integer로 반환
+     *  ex) @OwnerCheck(idParam = "boardId", ...) -> 메서드의 boardId 값을 찾아 사용
+     *
+     * @param joinPoint 현재 실행된 메서드의 실행 정보
+     * @param idParam   검증 대상 리소스 ID의 파라미터 이름 (예: "boardId" 문자열)
+     * @return 접근 검증 대상이 되는 리소스의 ID 값
+     */
+    private Integer extractTargetIdFromParams(JoinPoint joinPoint, String idParam) {
+        Object[] args = joinPoint.getArgs(); // 메서드 실제 인자 값 배열
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        String[] paramNames = signature.getParameterNames(); // 메서드 파라미터 이름 배열
+
+        for (int i = 0; i < paramNames.length; i++) {
+            if (paramNames[i].equals(idParam)) {
+                return Integer.parseInt(args[i].toString());
+            }
+        }
+        log.error("{}' 파라미터를 찾을 수 없음. 실제 파라미터: {}", idParam, Arrays.toString(paramNames));
+        throw new IllegalArgumentException("요청 파라미터에서 ID를 찾을 수 없습니다.");
+    }
+
+
+    // SecurityContext 에서 인증된 사용자 반한
+    private Authentication validateAuthenticatedUser() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || !auth.isAuthenticated() || "anonymousUser".equals(auth.getPrincipal())) {
+            log.error("인증 실패: SecurityContext에 인증된 사용자가 없습니다.");
+            throw new SecurityException("로그인된 사용자만 접근 가능합니다.");
+        }
+        return auth;
+    }
+
+
+    // 인증 객체에서 현재 로그인한 사용자 memberId 추출
+    private Integer extractMemberId(Authentication auth) {
+        Object principal = auth.getPrincipal();
+        if (principal instanceof CustomUserDetails u) return u.getMemberId();
+        if (principal instanceof CustomOAuth2User u) return u.getMemberId();
+        log.error("인증 실패: 사용자 객체 타입이 예상과 다름. principal = {}", principal.getClass().getName());
+        throw new SecurityException("인증 정보가 없습니다.");
+    }
+
+
+    // 서비스 이름에 따라 해당 리소스의 작성자 조회
+    private Integer findOwnerIdByServiceName(String service, Integer targetId) {
+        return switch (service) {
+            case "boardService"  -> boardService.findMemberIdByBoardId(targetId);
+            case "commentService" -> commentService.findMemberIdByCommentId(targetId);
+            case "memberService" -> targetId;
+            default -> {
+                log.error("지원하지 않는 서비스명 '{}'", service);
+                throw new IllegalArgumentException("지원하지 않는 서비스명입니다.");
+            }
+        };
+    }
+
+}

--- a/src/main/java/com/web/SearchWeb/board/controller/BoardController.java
+++ b/src/main/java/com/web/SearchWeb/board/controller/BoardController.java
@@ -1,5 +1,6 @@
 package com.web.SearchWeb.board.controller;
 
+import com.web.SearchWeb.aop.OwnerCheck;
 import com.web.SearchWeb.board.domain.Board;
 import com.web.SearchWeb.board.dto.BoardDto;
 import com.web.SearchWeb.board.service.BoardService;
@@ -133,34 +134,9 @@ public class BoardController {
      *  게시글 수정
      */
     @PostMapping("/board/{boardId}/update")
-    public String updateBoard(@PathVariable int boardId, BoardDto boardDto, @AuthenticationPrincipal Object currentUser){
-
-
-        // 로그인 된 경우
-        int memberId;
-        if(currentUser instanceof UserDetails) {
-            // 일반 로그인 사용자 처리
-            memberId = ((CustomUserDetails) currentUser).getMemberId();
-        }
-        else if(currentUser instanceof OAuth2User) {
-            // 소셜 로그인 사용자 처리
-            memberId = ((CustomOAuth2User) currentUser).getMemberId();
-        } else {
-            return "redirect:/error";
-        }
-
-
-        // 수정하려는 게시글의 정보 가져오기
-        Map<String, Object> boardData = boardservice.selectBoard(boardId);
-        Board board = (Board) boardData.get("board");
-
-        // 게시글이 존재하지 않거나, 로그인한 사용자가 작성자가 아닌 경우 접근 거부
-        if (board == null || (board.getMember_memberId() != memberId)) {
-            return "redirect:/access-denied";
-        }
-
+    @OwnerCheck(idParam = "boardId", service = "boardService")
+    public String updateBoard(@PathVariable int boardId, BoardDto boardDto){
         boardservice.updateBoard(boardId, boardDto);
-
         return "redirect:/board/{boardId}";
     }
 
@@ -169,33 +145,9 @@ public class BoardController {
      *  게시글 삭제
      */
     @PostMapping("/board/{boardId}/delete")
-    public String deleteBoard(@PathVariable int boardId, @AuthenticationPrincipal Object currentUser) {
-
-        // 로그인 된 경우
-        int memberId;
-        if(currentUser instanceof UserDetails) {
-            // 일반 로그인 사용자 처리
-            memberId = ((CustomUserDetails) currentUser).getMemberId();
-        }
-        else if(currentUser instanceof OAuth2User) {
-            // 소셜 로그인 사용자 처리
-            memberId = ((CustomOAuth2User) currentUser).getMemberId();
-        } else {
-            return "redirect:/error";
-        }
-
-        // 삭제하려는 게시글의 정보 가져오기
-        Map<String, Object> boardData = boardservice.selectBoard(boardId);
-        Board board = (Board) boardData.get("board");
-
-        // 게시글이 존재하지 않거나, 로그인한 사용자가 작성자가 아닌 경우 접근 거부
-        if (board == null || (board.getMember_memberId() != memberId)) {
-            return "redirect:/access-denied";
-        }
-
-        // 게시글 삭제 수행
-        boardservice.deleteBoard(memberId, boardId);
-
+    @OwnerCheck(idParam = "boardId", service = "boardService")
+    public String deleteBoard(@PathVariable int boardId) {
+        boardservice.deleteBoard(boardId);
         return "redirect:/board";
     }
 

--- a/src/main/java/com/web/SearchWeb/board/dao/BoardDao.java
+++ b/src/main/java/com/web/SearchWeb/board/dao/BoardDao.java
@@ -34,7 +34,7 @@ public interface BoardDao {
     int updateBoardProfile(int boardId, String job, String major);
 
      //게시글 삭제
-    int deleteBoard(int memberId, int boardId);
+    int deleteBoard(int boardId);
 
     //게시글 북마크 수 수정
     int updateBookmarkCount(int boardId, int bookmarkCount);

--- a/src/main/java/com/web/SearchWeb/board/dao/MybatisBoardDao.java
+++ b/src/main/java/com/web/SearchWeb/board/dao/MybatisBoardDao.java
@@ -80,8 +80,8 @@ public class MybatisBoardDao implements BoardDao{
     /**
      *  게시글 삭제
      */
-    public int deleteBoard(int memberId, int boardId) {
-        return mapper.deleteBoard(memberId, boardId);
+    public int deleteBoard(int boardId) {
+        return mapper.deleteBoard(boardId);
     }
 
 

--- a/src/main/java/com/web/SearchWeb/board/service/BoardService.java
+++ b/src/main/java/com/web/SearchWeb/board/service/BoardService.java
@@ -94,8 +94,8 @@ public class BoardService {
     /**
      *  게시글 삭제
      */
-    public int deleteBoard(int memberId, int boardId) {
-        return boardDao.deleteBoard(memberId, boardId);
+    public int deleteBoard(int boardId) {
+        return boardDao.deleteBoard(boardId);
     }
 
 
@@ -124,5 +124,13 @@ public class BoardService {
         } else {
             throw new IllegalArgumentException("Invalid board ID");
         }
+    }
+
+
+    // 게시글 소유자(작성자) 조회
+    public int findMemberIdByBoardId(int boardId) {
+        Board board = boardDao.selectBoard(boardId);
+        if (board == null) throw new IllegalArgumentException("게시글이 존재하지 않습니다.");
+        return board.getMember_memberId();
     }
 }

--- a/src/main/java/com/web/SearchWeb/comment/controller/CommentApiController.java
+++ b/src/main/java/com/web/SearchWeb/comment/controller/CommentApiController.java
@@ -1,10 +1,9 @@
 package com.web.SearchWeb.comment.controller;
 
-import com.web.SearchWeb.comment.dao.CommentDao;
+import com.web.SearchWeb.aop.OwnerCheck;
 import com.web.SearchWeb.comment.domain.Comment;
 import com.web.SearchWeb.comment.dto.CommentDto;
 import com.web.SearchWeb.comment.service.CommentService;
-import com.web.SearchWeb.member.domain.Member;
 import com.web.SearchWeb.member.dto.CustomOAuth2User;
 import com.web.SearchWeb.member.dto.CustomUserDetails;
 import com.web.SearchWeb.member.service.MemberService;
@@ -25,12 +24,10 @@ import java.util.Map;
 public class CommentApiController {
 
     private final CommentService commentService;
-    private final MemberService memberService;
 
     @Autowired
-    public CommentApiController(CommentService commentService, MemberService memberService) {
+    public CommentApiController(CommentService commentService) {
         this.commentService = commentService;
-        this.memberService = memberService;
     }
 
 
@@ -87,6 +84,7 @@ public class CommentApiController {
      *  게시글 댓글 단일 조회
      */
     @GetMapping("board/{boardId}/comment/{commentId}")
+    @OwnerCheck(idParam = "commentId", service = "commentService")
     public ResponseEntity<Comment> selectComment(@PathVariable int commentId){
         Comment comment = commentService.selectComment(commentId);
         return ResponseEntity.ok(comment);
@@ -97,46 +95,12 @@ public class CommentApiController {
      *  게시글 댓글 수정
      */
     @PutMapping("board/{boardId}/comments/{commentId}")
+    @OwnerCheck(idParam = "commentId", service = "commentService")
     public ResponseEntity<Map<String, Object>> updateComment(@PathVariable int boardId,
                                                              @PathVariable int commentId,
-                                                             @AuthenticationPrincipal Object currentUser,
                                                              @RequestBody CommentDto commentDto){
-
         Map<String, Object> response = new HashMap<>();
-
-        // 로그인 되지 않은 경우
-        if (currentUser == null || "anonymousUser".equals(currentUser)) {
-            return ResponseEntity
-                    .status(HttpStatus.UNAUTHORIZED)
-                    .body(response); // 401 Unauthorized 응답
-        }
-
-        // 로그인 된 경우
-        String username;
-        if(currentUser instanceof UserDetails) {
-            // 일반 로그인 사용자 처리
-            username = ((CustomUserDetails) currentUser).getUsername();
-        }
-        else if(currentUser instanceof OAuth2User) {
-            // 소셜 로그인 사용자 처리
-            username = ((CustomOAuth2User) currentUser).getUsername();
-        } else {
-            return ResponseEntity
-                    .status(HttpStatus.FORBIDDEN)
-                    .body(response);  // 403 Forbidden 응답
-        }
-
-        Member loggedInMember = memberService.findByUserName(username);
-        Comment comment = commentService.selectComment(commentId);
-
-        if(comment.getMember_memberId() != loggedInMember.getMemberId()){
-            return ResponseEntity
-                    .status(HttpStatus.FORBIDDEN)
-                    .body(response); // 403 Forbidden 응답
-        }
-
-        commentService.updateComment(commentId, loggedInMember, commentDto);
-
+        commentService.updateComment(commentId, commentDto);
         response.put("success", true);
         return ResponseEntity.ok(response);  // 200 OK 응답
     }
@@ -146,47 +110,12 @@ public class CommentApiController {
      *  게시글 댓글 삭제
      */
     @DeleteMapping("board/{boardId}/comments/{commentId}")
+    @OwnerCheck(idParam = "commentId", service = "commentService")
     public ResponseEntity<Map<String, Object>> deleteComment(@PathVariable int boardId,
-                                                             @PathVariable int commentId,
-                                                             @AuthenticationPrincipal Object currentUser){
-
+                                                             @PathVariable int commentId){
         Map<String, Object> response = new HashMap<>();
-
-        // 로그인 되지 않은 경우
-        if (currentUser == null || "anonymousUser".equals(currentUser)) {
-            return ResponseEntity
-                    .status(HttpStatus.UNAUTHORIZED)
-                    .body(response); // 401 Unauthorized 응답
-        }
-
-        // 로그인 된 경우
-        String username;
-        if(currentUser instanceof UserDetails) {
-            // 일반 로그인 사용자 처리
-            username = ((CustomUserDetails) currentUser).getUsername();
-        }
-        else if(currentUser instanceof OAuth2User) {
-            // 소셜 로그인 사용자 처리
-            username = ((CustomOAuth2User) currentUser).getUsername();
-        } else {
-            return ResponseEntity
-                    .status(HttpStatus.FORBIDDEN)
-                    .body(response);  // 403 Forbidden 응답
-        }
-
-        Member loggedInMember = memberService.findByUserName(username);
-        Comment comment = commentService.selectComment(commentId);
-
-        if(comment.getMember_memberId() != loggedInMember.getMemberId()){
-            return ResponseEntity
-                    .status(HttpStatus.FORBIDDEN)
-                    .body(response); // 403 Forbidden 응답
-        }
-
         commentService.deleteComment(boardId, commentId);
-
         response.put("success", true);
         return ResponseEntity.ok(response);  // 200 OK 응답
     }
-
 }

--- a/src/main/java/com/web/SearchWeb/comment/dao/CommentDao.java
+++ b/src/main/java/com/web/SearchWeb/comment/dao/CommentDao.java
@@ -1,6 +1,7 @@
 package com.web.SearchWeb.comment.dao;
 
 import com.web.SearchWeb.comment.domain.Comment;
+import com.web.SearchWeb.comment.dto.CommentDto;
 
 import java.util.List;
 
@@ -15,7 +16,7 @@ public interface CommentDao {
    Comment selectComment(int commentId);
 
     //게시글 댓글 수정
-    int updateComment(Comment commentId);
+    int updateComment(int commentId, CommentDto commentDto);
 
     //게시글 댓글 삭제
     int deleteComment(int commentId);

--- a/src/main/java/com/web/SearchWeb/comment/dao/MybatisCommentDao.java
+++ b/src/main/java/com/web/SearchWeb/comment/dao/MybatisCommentDao.java
@@ -49,8 +49,8 @@ public class MybatisCommentDao implements CommentDao{
     /**
      *  게시글 댓글 수정
      */
-    public int updateComment(Comment comment) {
-        return mapper.updateComment(comment);
+    public int updateComment(int commentId, CommentDto commentDto) {
+        return mapper.updateComment(commentId, commentDto);
     }
 
 

--- a/src/main/java/com/web/SearchWeb/comment/service/CommentService.java
+++ b/src/main/java/com/web/SearchWeb/comment/service/CommentService.java
@@ -69,16 +69,8 @@ public class CommentService {
     /**
      *  게시글 댓글 수정
      */
-    public int updateComment(int commentId, Member member, CommentDto commentDto){
-        Comment comment = new Comment();
-        comment.setCommentId(commentId);
-        comment.setBoard_boardId(commentDto.getBoard_boardId());
-        comment.setMember_memberId(member.getMemberId());
-        comment.setMember_nickname(member.getNickname());
-        comment.setMember_job(member.getJob());
-        comment.setMember_major(member.getMajor());
-        comment.setContent(commentDto.getContent());
-        return commentdao.updateComment(comment);
+    public int updateComment(int commentId, CommentDto commentDto){
+        return commentdao.updateComment(commentId, commentDto);
     }
 
 
@@ -101,5 +93,13 @@ public class CommentService {
      */
     public int getCommentCount(int boardId) {
         return commentdao.countComments(boardId);
+    }
+
+
+    // 댓글 소유자(작성자) 조회
+    public int findMemberIdByCommentId(int commentId) {
+        Comment comment = commentdao.selectComment(commentId);
+        if (comment == null) throw new IllegalArgumentException("게시글이 존재하지 않습니다.");
+        return comment.getMember_memberId();
     }
 }

--- a/src/main/java/com/web/SearchWeb/mypage/controller/MyPageController.java
+++ b/src/main/java/com/web/SearchWeb/mypage/controller/MyPageController.java
@@ -1,18 +1,14 @@
 package com.web.SearchWeb.mypage.controller;
 
+import com.web.SearchWeb.aop.OwnerCheck;
 import com.web.SearchWeb.bookmark.domain.Bookmark;
 import com.web.SearchWeb.bookmark.dto.BookmarkDto;
 import com.web.SearchWeb.bookmark.service.BookmarkService;
 import com.web.SearchWeb.member.domain.Member;
-import com.web.SearchWeb.member.dto.CustomOAuth2User;
-import com.web.SearchWeb.member.dto.CustomUserDetails;
 import com.web.SearchWeb.member.dto.MemberUpdateDto;
 import com.web.SearchWeb.member.service.MemberService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.authentication.AnonymousAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
@@ -52,38 +48,10 @@ public class MyPageController {
      * 마이페이지 (사용자 정보 조회)
      */
     @GetMapping("/myPage/{memberId}")
+    @OwnerCheck(idParam = "memberId", service = "memberService")
     public String myPage(@PathVariable int memberId, Model model){
-        // 현재 사용자의 Authentication 객체 가져오기
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-
-        // 사용자가 로그인되어 있는지 확인
-        if (authentication instanceof AnonymousAuthenticationToken) {
-            return "redirect:/login"; // 사용자가 로그인되지 않은 경우, 로그인 페이지로 리디렉션
-        }
-
-        // 현재 로그인된 사용자의 정보 가져오기
-        int currentUserId = -1;
-        if (authentication.getPrincipal() instanceof CustomUserDetails) {
-            // 일반 로그인 사용자 처리
-            CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
-            currentUserId = userDetails.getMemberId();
-
-        } else if (authentication.getPrincipal() instanceof CustomOAuth2User) {
-            // 소셜 로그인 사용자 처리
-            CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
-            currentUserId = oAuth2User.getMemberId();
-        }
-
-
-        // 요청된 memberId와 현재 로그인된 사용자의 ID 비교
-        if (currentUserId != memberId) {
-            return "redirect:/access-denied"; // 접근이 허용되지 않은 경우, 접근 거부 페이지로 리디렉션
-        }
-
-        // 사용자의 ID로 사용자 조회
         Member member = memberService.findByMemberId(memberId);
         model.addAttribute("member", member);
-
         return "mypage/myPage";
     }
     
@@ -92,6 +60,7 @@ public class MyPageController {
      *  마이페이지 (사용자 프로필 수정)
      */
     @PutMapping("/myPage/{memberId}/profile")
+    @OwnerCheck(idParam = "memberId", service = "memberService")
     public ResponseEntity<Integer> updateProfile(@PathVariable final int memberId, @RequestBody MemberUpdateDto memberUpdateDto) {
         return ResponseEntity.ok(memberService.updateMember(memberId, memberUpdateDto));
     }
@@ -102,6 +71,7 @@ public class MyPageController {
      *  북마크 추가 (마이페이지에서 추가)
      */
     @PostMapping(value ="/myPage/{memberId}/bookmark")
+    @OwnerCheck(idParam = "memberId", service = "memberService")
     public ResponseEntity<BookmarkDto> insertBookmark(@PathVariable final int memberId, @RequestBody BookmarkDto bookmarkdto){
         bookmarkService.insertBookmarkForUser(bookmarkdto);
         return ResponseEntity.ok(bookmarkdto);
@@ -113,6 +83,7 @@ public class MyPageController {
      *  마이페이지 북마크 목록 조회
      */
     @GetMapping(value ="/myPage/{memberId}/bookmarks")
+    @OwnerCheck(idParam = "memberId", service = "memberService")
     public ResponseEntity<List<Bookmark>> getBookmarks(@PathVariable final int memberId,
                                                        @RequestParam(required = false) String query,
                                                        @RequestParam(defaultValue = "All") String tag,
@@ -138,6 +109,7 @@ public class MyPageController {
      *  태그 조회
      */
     @GetMapping("/myPage/{memberId}/tags")
+    @OwnerCheck(idParam = "memberId", service = "memberService")
     public ResponseEntity<List<String>> getTags(@PathVariable final int memberId) {
         List<String> tags = bookmarkService.selectTags(memberId);
         return ResponseEntity.ok(tags);
@@ -148,6 +120,7 @@ public class MyPageController {
      *  마이페이지 북마크 단일 조회
      */
     @GetMapping("/myPage/{memberId}/bookmark/{bookmarkId}")
+    @OwnerCheck(idParam = "memberId", service = "memberService")
     public ResponseEntity<Bookmark> getBookmark(@PathVariable final int memberId, @PathVariable final int bookmarkId) {
         Bookmark bookmark = bookmarkService.selectBookmark(memberId, bookmarkId);
         return ResponseEntity.ok(bookmark);
@@ -158,6 +131,7 @@ public class MyPageController {
      *  마이페이지 북마크 수정
      */
     @PutMapping("/myPage/{memberId}/bookmark/{bookmarkId}")
+    @OwnerCheck(idParam = "memberId", service = "memberService")
     public ResponseEntity<Integer> updateBookmark(@PathVariable final int memberId,
                                                   @PathVariable final int bookmarkId,
                                                   @RequestBody BookmarkDto bookmarkDto) {
@@ -170,6 +144,7 @@ public class MyPageController {
      *  마이페이지 북마크 삭제
      */
     @DeleteMapping("/myPage/{memberId}/bookmark/{bookmarkId}")
+    @OwnerCheck(idParam = "memberId", service = "memberService")
     public ResponseEntity<Integer> deleteBookmark(@PathVariable final int memberId, @PathVariable final int bookmarkId) {
         int result = bookmarkService.deleteBookmarkMyPage(memberId, bookmarkId);
         return ResponseEntity.ok(result);

--- a/src/main/resources/mapper/board-mapper.xml
+++ b/src/main/resources/mapper/board-mapper.xml
@@ -125,9 +125,6 @@
         delete from board
         where
         boardId = #{boardId}
-        and
-        member_memberId = #{memberId}
-
     </delete>
 
 

--- a/src/main/resources/mapper/comment-mapper.xml
+++ b/src/main/resources/mapper/comment-mapper.xml
@@ -34,12 +34,7 @@
     <update id="updateComment" parameterType="com.web.SearchWeb.comment.domain.Comment">
         update comment
         set
-        board_boardId = #{board_boardId},
-        member_memberId = #{member_memberId},
-        member_nickname = #{member_nickname},
-        member_job = #{member_job},
-        member_major = #{member_major},
-        content = #{content}
+        content = #{commentDto.content}
         WHERE
         commentId = #{commentId}
     </update>


### PR DESCRIPTION
## 💡 이슈
resolve {#6}

## 🤩 개요
- Spring AOP를 도입하여 핵심 기능(컨트롤러 메서드)과 부가기능(소유자 검증)을 분리.


## 🧑‍💻 작업 사항
- @OwnerCheck() 커스텀 어노테이션을 정의하고, 어노테이션이 붙은 메서드 실행 전 소유자 검증을 수행하는 AOP클래스 구현

## 📖 참고 사항
공유할 내용, 레퍼런스, 추가로 발생할 것으로 예상되는 이슈, 스크린샷 등을 넣어 주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - 컨트롤러 메서드에 @OwnerCheck 어노테이션을 도입하여 게시글, 댓글, 마이페이지 등 주요 리소스의 소유자 검증을 자동화하였습니다.
  - 소유자 검증 로직이 AOP 기반으로 통합되어, 인증 및 권한 확인이 일관되고 투명하게 처리됩니다.

- **Refactor**
  - 게시글, 댓글, 마이페이지 관련 컨트롤러에서 수동 인증·권한 체크 코드를 제거하고, 메서드 시그니처를 간소화했습니다.
  - 서비스 및 DAO 계층의 메서드 시그니처가 간소화되고, 불필요한 파라미터가 제거되었습니다.

- **Bug Fixes**
  - 댓글 수정 SQL이 불필요한 필드까지 변경하던 문제를 해결하고, 실제 수정이 필요한 내용만 갱신하도록 개선했습니다.

- **Chores**
  - Spring AOP 관련 라이브러리 의존성을 추가하여, 새로운 소유자 검증 기능이 정상 동작하도록 하였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->