### PR TITLE
Feat/sw 76 - 반응형 UI/UX 대응 및 폴더 북마크 수 정렬 구현

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -66,6 +66,18 @@
 
   /* Custom breakpoint: 1400px — 데스크톱/태블릿 구분 기준 */
   --breakpoint-tablet-lg: 87.5rem; /* 1400px */
+
+  /* Semantic z-index Scale */
+  --z-index-below: -1;
+  --z-index-base: 0;
+  --z-index-sticky: 20;
+  --z-index-floating: 50;
+  --z-index-drawer-backdrop: 100;
+  --z-index-drawer: 101;
+  --z-index-dialog-backdrop: 150;
+  --z-index-dialog: 160;
+  --z-index-popover: 200;
+  --z-index-toast: 300;
 }
 
 :root {

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -63,6 +63,9 @@
   --radius-2xl: calc(var(--radius) + 8px);
   --radius-3xl: calc(var(--radius) + 12px);
   --radius-4xl: calc(var(--radius) + 16px);
+
+  /* Custom breakpoint: 1400px — 데스크톱/태블릿 구분 기준 */
+  --breakpoint-tablet-lg: 87.5rem; /* 1400px */
 }
 
 :root {

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -3,18 +3,26 @@
 import React, { useEffect, useState } from "react";
 import NextLink from "next/link";
 import Image from "next/image";
-import { motion, AnimatePresence } from "framer-motion";
-import { Input } from "@/components/ui/input";
+import { motion } from "framer-motion";
 import { buildBackendUrl } from "@/lib/config/backend";
 import { LandingHeader } from "@/components/layout/LandingHeader";
 
 export default function LoginPage() {
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
   return (
     <div className="relative flex min-h-screen w-full flex-col overflow-x-hidden w-screen text-text-main font-sans selection:bg-primary/20 bg-background-light dark:bg-background-dark">
       {/* Sync Header with Landing Page (page.tsx) */}
       <LandingHeader isLoginPage />
 
-      <main className="flex flex-1 flex-col lg:flex-row min-h-0 pt-11">
+      {/* ========================================================
+          1. DESKTOP VERSION (lg:flex, hidden on mobile)
+             - This is 100% identical to the original code layout.
+         ======================================================== */}
+      <main className="hidden lg:flex flex-1 flex-row min-h-0 pt-11">
         {/* Left Section: Visual Assets (Galaxy Background) */}
         <div className="relative flex w-full flex-col items-center justify-center overflow-hidden border-r border-slate-100 dark:border-white/5 bg-[#F5F3FF] dark:bg-[#020617] p-8 lg:w-1/2 lg:p-12 min-h-[400px] transition-colors duration-1000">
           {/* Cosmic Background System (Light: Crystal Aurora / Dark: Galaxy) */}
@@ -34,25 +42,27 @@ export default function LoginPage() {
             ></div>
 
             {/* Dense Star/Light Field (Twinkling Crystal Shards) - Hidden in Light Mode */}
-            <div className="absolute inset-0 hidden dark:block">
-              {Array.from({ length: 45 }).map((_, i) => (
-                <div 
-                  key={`star-${i}`}
-                  className="absolute rounded-full transition-all duration-1000"
-                  style={{ 
-                    left: `${Math.random() * 100}%`,
-                    top: `${Math.random() * 100}%`,
-                    width: `${Math.random() * 2.5 + 0.5}px`,
-                    height: `${Math.random() * 2.5 + 0.5}px`,
-                    // Light mode: Prism effect (shades of indigo/cyan/white)
-                    backgroundColor: i % 4 === 0 ? "#7c3aed" : i % 5 === 0 ? "#0ea5e9" : "#ffffff",
-                    opacity: 0.4,
-                    animation: i % 3 === 0 ? `twinkle ${Math.random() * 3 + 2}s ease-in-out infinite ${Math.random() * 5}s` : 'none',
-                    boxShadow: i % 8 === 0 ? '0 0 10px 1px rgba(124,58,237,0.3)' : i % 12 === 0 ? '0 0 12px 2px rgba(14,165,233,0.3)' : 'none'
-                  }}
-                ></div>
-              ))}
-            </div>
+            {mounted && (
+              <div className="absolute inset-0 hidden dark:block">
+                {Array.from({ length: 45 }).map((_, i) => (
+                  <div 
+                    key={`star-${i}`}
+                    className="absolute rounded-full transition-all duration-1000"
+                    style={{ 
+                      left: `${Math.random() * 100}%`,
+                      top: `${Math.random() * 100}%`,
+                      width: `${Math.random() * 2.5 + 0.5}px`,
+                      height: `${Math.random() * 2.5 + 0.5}px`,
+                      // Light mode: Prism effect (shades of indigo/cyan/white)
+                      backgroundColor: i % 4 === 0 ? "#7c3aed" : i % 5 === 0 ? "#0ea5e9" : "#ffffff",
+                      opacity: 0.4,
+                      animation: i % 3 === 0 ? `twinkle ${Math.random() * 3 + 2}s ease-in-out infinite ${Math.random() * 5}s` : 'none',
+                      boxShadow: i % 8 === 0 ? '0 0 10px 1px rgba(124,58,237,0.3)' : i % 12 === 0 ? '0 0 12px 2px rgba(14,165,233,0.3)' : 'none'
+                    }}
+                  ></div>
+                ))}
+              </div>
+            )}
           </div>
 
           <div className="relative z-10 flex w-full flex-col items-center justify-center text-center -mt-10">
@@ -61,7 +71,7 @@ export default function LoginPage() {
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.8 }}
-              className="mb-16 flex w-full max-w-md flex-col items-center"
+              className="mb-16 hidden lg:flex w-full max-w-md flex-col items-center"
             >
               <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-primary/20 bg-white/50 dark:bg-white/5 backdrop-blur-md px-4 py-1.5 text-[10px] font-bold tracking-[0.2em] text-primary shadow-sm">
                 BETA SERVICE
@@ -77,7 +87,7 @@ export default function LoginPage() {
             </motion.div>
 
             {/* 3D Visuals & Orbiting Icons */}
-            <div className="relative flex h-[350px] w-full max-w-lg items-center justify-center scale-90 sm:scale-100" style={{ perspective: "1200px", transformStyle: "preserve-3d" }}>
+            <div className="relative flex h-[280px] lg:h-[350px] w-full max-w-lg items-center justify-center scale-75 xs:scale-85 lg:scale-100" style={{ perspective: "1200px", transformStyle: "preserve-3d" }}>
               {/* Data Particles (Digital Dust) - Integrated with Star Field - Hidden in Light Mode */}
               <div className="absolute inset-x-[-20%] inset-y-[-20%] pointer-events-none -z-10 hidden dark:block" style={{ transformStyle: "preserve-3d" }}>
                 {[
@@ -89,7 +99,7 @@ export default function LoginPage() {
                   { l: "55%", t: "45%", z: "180px", d: "-5s" },
                 ].map((p, i) => (
                   <div 
-                    key={`part-${i}`}
+                    key={`part-desktop-${i}`}
                     className="absolute h-[3px] w-[3px] bg-primary/60 dark:bg-primary/80 rounded-full shadow-[0_0_8px_rgba(124,58,237,0.6)]"
                     style={{ 
                       left: p.l,
@@ -178,7 +188,7 @@ export default function LoginPage() {
                   { icon: "favorite", color: "text-pink-500", offset: "-16s" },
                 ].map((item, i) => (
                   <div 
-                    key={`ring1-${i}`}
+                    key={`ring1-desktop-${i}`}
                     className="absolute left-1/2 top-1/2 -ml-5 -mt-5 transition-all duration-300"
                     style={{ 
                       animation: `orbit 20s linear infinite ${item.offset}`,
@@ -198,7 +208,7 @@ export default function LoginPage() {
                   </div>
                 ))}
 
-                {/* Orbiting Icons - Ring 2 (Reverse) */}
+                {/* Orbiting Icons - Ring 2 */}
                 {[
                   { icon: "code", color: "text-indigo-500", offset: "0s" },
                   { icon: "flight", color: "text-cyan-500", offset: "-6s" },
@@ -207,7 +217,7 @@ export default function LoginPage() {
                   { icon: "lightbulb", color: "text-amber-500", offset: "-24s" },
                 ].map((item, i) => (
                   <div 
-                    key={`ring2-${i}`}
+                    key={`ring2-desktop-${i}`}
                     className="absolute left-1/2 top-1/2 -ml-6 -mt-6 transition-all duration-300"
                     style={{ 
                       animation: `orbit-reverse 30s linear infinite ${item.offset}`,
@@ -322,6 +332,135 @@ export default function LoginPage() {
               <p className="mt-10 text-[11px] text-slate-400 dark:text-slate-500 leading-relaxed">
                 로그인함으로써 ReLink의 <br />
                 <a href="#" className="underline hover:text-primary transition-colors font-medium">이용약관</a> 및 <a href="#" className="underline hover:text-primary transition-colors font-medium">개인정보처리방침</a>에 동의하게 됩니다.
+              </p>
+            </div>
+          </motion.div>
+        </div>
+      </main>
+
+      {/* ========================================================
+          2. MOBILE VERSION (lg:hidden, flex-col layout overlay)
+         ======================================================== */}
+      <main className="relative lg:hidden flex flex-1 flex-col min-h-0 pt-11">
+        {/* Background Overlay (Galaxy Background matching desktop left section) */}
+        <div className="fixed inset-0 z-0 flex w-full flex-col items-center justify-center overflow-hidden bg-[#F5F3FF] dark:bg-[#020617] transition-colors duration-1000">
+          {/* Cosmic Background System */}
+          <div className="pointer-events-none absolute inset-0 overflow-hidden">
+            <div 
+              className="absolute -left-[10%] -top-[10%] h-[80%] w-[80%] rounded-full bg-primary/20 dark:bg-primary/20 blur-[120px]"
+              style={{ animation: "nebula-pulse 15s ease-in-out infinite" }}
+            ></div>
+            <div 
+              className="absolute -right-[15%] bottom-[10%] h-[70%] w-[70%] rounded-full bg-cyan-400/20 dark:bg-indigo-600/15 blur-[100px]"
+              style={{ animation: "nebula-pulse 20s ease-in-out infinite reverse" }}
+            ></div>
+            <div 
+              className="absolute left-[20%] top-[30%] h-[40%] w-[40%] rounded-full bg-pink-400/25 dark:bg-violet-500/15 blur-[90px]"
+              style={{ animation: "rotate-slow 30s linear infinite" }}
+            ></div>
+
+            {mounted && (
+              <div className="absolute inset-0 hidden dark:block">
+                {Array.from({ length: 45 }).map((_, i) => (
+                  <div 
+                    key={`star-mobile-${i}`}
+                    className="absolute rounded-full transition-all duration-1000"
+                    style={{ 
+                      left: `${Math.random() * 100}%`,
+                      top: `${Math.random() * 100}%`,
+                      width: `${Math.random() * 2.5 + 0.5}px`,
+                      height: `${Math.random() * 2.5 + 0.5}px`,
+                      backgroundColor: i % 4 === 0 ? "#7c3aed" : i % 5 === 0 ? "#0ea5e9" : "#ffffff",
+                      opacity: 0.5,
+                      animation: i % 3 === 0 ? `twinkle ${Math.random() * 3 + 2}s ease-in-out infinite ${Math.random() * 5}s` : 'none',
+                      boxShadow: i % 8 === 0 ? '0 0 10px 1px rgba(124,58,237,0.3)' : i % 12 === 0 ? '0 0 12px 2px rgba(14,165,233,0.3)' : 'none'
+                    }}
+                  ></div>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Sign In Form (Floating on top of the galaxy background) */}
+        <div className="relative z-10 flex w-full flex-col items-center justify-center bg-transparent p-6 min-h-[calc(100vh-44px)]">
+          <motion.div 
+            initial={{ opacity: 0, scale: 0.95, y: 10 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            transition={{ duration: 0.6, delay: 0.1 }}
+            className="w-full max-w-[380px] text-center flex flex-col justify-center my-auto"
+          >
+            <div className="glass-card w-full rounded-[28px] bg-white/75 dark:bg-slate-900/60 p-8 shadow-[0_32px_64px_rgba(124,58,237,0.15)] dark:shadow-[0_32px_80px_rgba(0,0,0,0.6)] backdrop-blur-2xl border border-white/50 dark:border-white/10 relative overflow-hidden">
+              {/* Inner card subtle glow */}
+              <div className="absolute inset-0 bg-gradient-to-br from-white/40 to-transparent dark:from-white/5 dark:to-transparent pointer-events-none rounded-[28px]"></div>
+              
+              <div className="mb-6 flex flex-col items-center relative z-10">
+                <div className="mb-2 flex h-20 w-20 items-center justify-center relative">
+                  <div className="absolute inset-0 bg-primary/30 blur-2xl rounded-full scale-75 opacity-60"></div>
+                  <div className="relative h-[56px] w-[56px]">
+                    <Image
+                      src="/relink_logo.png"
+                      alt="ReLink Logo"
+                      width={512} 
+                      height={512}
+                      unoptimized={true}
+                      priority
+                      className="h-full w-full object-contain rounded-2xl drop-shadow-[0_8px_16px_rgba(109,40,217,0.4)]"
+                    />
+                  </div>
+                </div>
+                <h3 className="mb-2 text-[26px] font-black text-text-main tracking-tight bg-clip-text">Hello ReLink!</h3>
+                <p className="text-text-sub text-[14px] font-medium leading-relaxed">
+                  당신의 링크, 이제 AI와 함께<br/>스마트하게 관리하세요
+                </p>
+              </div>
+
+              <div className="relative z-10">
+                <button 
+                  type="button" 
+                  onClick={() => { window.location.href = buildBackendUrl('/oauth2/authorization/google'); }} 
+                  className="group relative mb-6 flex h-[48px] w-full items-center justify-center gap-3 rounded-xl border border-white/20 bg-gradient-to-br from-primary via-violet-500 to-indigo-600 text-white shadow-[0_8px_20px_-6px_rgba(109,40,217,0.6)] transition-all hover:scale-[1.02] active:scale-[0.98]"
+                >
+                  <div className="flex h-[22px] w-[22px] items-center justify-center rounded-full bg-white p-1 shadow-sm">
+                    <svg className="h-full w-full" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                      <title>Google Logo</title>
+                      <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4"></path>
+                      <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"></path>
+                      <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.26.81-.58z" fill="#FBBC05"></path>
+                      <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"></path>
+                    </svg>
+                  </div>
+                  <span className="text-[14px] font-bold tracking-tight">Google 계정으로 계속하기</span>
+                </button>
+              </div>
+
+              <div className="space-y-4 pt-6 mt-4 border-t border-slate-200/50 dark:border-white/10 relative z-10">
+                <p className="text-[10px] font-bold text-slate-400 dark:text-slate-400 tracking-[0.2em] text-center mb-4">Why ReLink?</p>
+                <div className="flex justify-between max-w-[240px] mx-auto">
+                  <div className="flex flex-col items-center gap-2">
+                    <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-indigo-50 text-indigo-600 dark:bg-indigo-500/20 dark:text-indigo-300 shadow-sm border border-indigo-100/50 dark:border-indigo-500/30">
+                      <span className="material-symbols-outlined text-[18px]">auto_awesome</span>
+                    </div>
+                    <span className="text-[11px] font-bold text-text-sub dark:text-slate-300 whitespace-nowrap">AI 자동 분류</span>
+                  </div>
+                  <div className="flex flex-col items-center gap-2">
+                    <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-blue-50 text-blue-600 dark:bg-blue-500/20 dark:text-blue-300 shadow-sm border border-blue-100/50 dark:border-blue-500/30">
+                      <span className="material-symbols-outlined text-[18px]">sync</span>
+                    </div>
+                    <span className="text-[11px] font-bold text-text-sub dark:text-slate-300 whitespace-nowrap">자동 동기화</span>
+                  </div>
+                  <div className="flex flex-col items-center gap-2">
+                    <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-purple-50 text-purple-600 dark:bg-purple-500/20 dark:text-purple-300 shadow-sm border border-purple-100/50 dark:border-purple-500/30">
+                      <span className="material-symbols-outlined text-[18px]">search</span>
+                    </div>
+                    <span className="text-[11px] font-bold text-text-sub dark:text-slate-300 whitespace-nowrap">강력한 검색</span>
+                  </div>
+                </div>
+              </div>
+
+              <p className="mt-8 text-[11px] text-slate-400 dark:text-slate-500 leading-relaxed relative z-10">
+                로그인함으로써 ReLink의 <br />
+                <a href="#" className="underline hover:text-primary dark:hover:text-violet-400 transition-colors font-medium">이용약관</a> 및 <a href="#" className="underline hover:text-primary dark:hover:text-violet-400 transition-colors font-medium">개인정보처리방침</a>에 동의하게 됩니다.
               </p>
             </div>
           </motion.div>

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,17 +1,14 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
+import React from "react";
 import NextLink from "next/link";
 import Image from "next/image";
 import { motion } from "framer-motion";
 import { buildBackendUrl } from "@/lib/config/backend";
 import { LandingHeader } from "@/components/layout/LandingHeader";
+import { StarField } from "@/components/ui/StarField";
 
 export default function LoginPage() {
-  const [mounted, setMounted] = useState(false);
-  useEffect(() => {
-    setMounted(true);
-  }, []);
 
   return (
     <div className="relative flex min-h-screen w-full flex-col overflow-x-hidden w-screen text-text-main font-sans selection:bg-primary/20 bg-background-light dark:bg-background-dark">
@@ -42,27 +39,7 @@ export default function LoginPage() {
             ></div>
 
             {/* Dense Star/Light Field (Twinkling Crystal Shards) - Hidden in Light Mode */}
-            {mounted && (
-              <div className="absolute inset-0 hidden dark:block">
-                {Array.from({ length: 45 }).map((_, i) => (
-                  <div 
-                    key={`star-${i}`}
-                    className="absolute rounded-full transition-all duration-1000"
-                    style={{ 
-                      left: `${Math.random() * 100}%`,
-                      top: `${Math.random() * 100}%`,
-                      width: `${Math.random() * 2.5 + 0.5}px`,
-                      height: `${Math.random() * 2.5 + 0.5}px`,
-                      // Light mode: Prism effect (shades of indigo/cyan/white)
-                      backgroundColor: i % 4 === 0 ? "#7c3aed" : i % 5 === 0 ? "#0ea5e9" : "#ffffff",
-                      opacity: 0.4,
-                      animation: i % 3 === 0 ? `twinkle ${Math.random() * 3 + 2}s ease-in-out infinite ${Math.random() * 5}s` : 'none',
-                      boxShadow: i % 8 === 0 ? '0 0 10px 1px rgba(124,58,237,0.3)' : i % 12 === 0 ? '0 0 12px 2px rgba(14,165,233,0.3)' : 'none'
-                    }}
-                  ></div>
-                ))}
-              </div>
-            )}
+            <StarField opacity={0.4} keyPrefix="desktop-star" />
           </div>
 
           <div className="relative z-10 flex w-full flex-col items-center justify-center text-center -mt-10">
@@ -359,26 +336,7 @@ export default function LoginPage() {
               style={{ animation: "rotate-slow 30s linear infinite" }}
             ></div>
 
-            {mounted && (
-              <div className="absolute inset-0 hidden dark:block">
-                {Array.from({ length: 45 }).map((_, i) => (
-                  <div 
-                    key={`star-mobile-${i}`}
-                    className="absolute rounded-full transition-all duration-1000"
-                    style={{ 
-                      left: `${Math.random() * 100}%`,
-                      top: `${Math.random() * 100}%`,
-                      width: `${Math.random() * 2.5 + 0.5}px`,
-                      height: `${Math.random() * 2.5 + 0.5}px`,
-                      backgroundColor: i % 4 === 0 ? "#7c3aed" : i % 5 === 0 ? "#0ea5e9" : "#ffffff",
-                      opacity: 0.5,
-                      animation: i % 3 === 0 ? `twinkle ${Math.random() * 3 + 2}s ease-in-out infinite ${Math.random() * 5}s` : 'none',
-                      boxShadow: i % 8 === 0 ? '0 0 10px 1px rgba(124,58,237,0.3)' : i % 12 === 0 ? '0 0 12px 2px rgba(14,165,233,0.3)' : 'none'
-                    }}
-                  ></div>
-                ))}
-              </div>
-            )}
+            <StarField opacity={0.5} keyPrefix="mobile-star" />
           </div>
         </div>
 

--- a/frontend/src/app/my-links/page.tsx
+++ b/frontend/src/app/my-links/page.tsx
@@ -15,7 +15,69 @@ import { cn } from '@/lib/utils';
 import { compareFolders } from '@/lib/utils/folderUtils';
 
 export default function MyLinksPage() {
-  const { toggleRightPanel } = useUIStore();
+  const { toggleRightPanel, toggleSaveLinkDialog, saveLinkDialogOpen } = useUIStore();
+  const [clipboardUrl, setClipboardUrl] = useState<string | null>(null);
+  const [isTooltipVisible, setIsTooltipVisible] = useState(false);
+  const [shouldRenderTooltip, setShouldRenderTooltip] = useState(false);
+
+  useEffect(() => {
+    const checkClipboard = async () => {
+      if (saveLinkDialogOpen) {
+        setClipboardUrl(null);
+        return;
+      }
+      if (typeof navigator === 'undefined' || !navigator.clipboard) {
+        return;
+      }
+      try {
+        const text = await navigator.clipboard.readText();
+        if (text && (text.startsWith('http://') || text.startsWith('https://'))) {
+          setClipboardUrl(text);
+        }
+      } catch (err) {
+        console.warn('Clipboard read error:', err);
+      }
+    };
+
+    checkClipboard();
+
+    window.addEventListener('focus', checkClipboard);
+    return () => {
+      window.removeEventListener('focus', checkClipboard);
+    };
+  }, [saveLinkDialogOpen]);
+
+  useEffect(() => {
+    let fadeInTimer: NodeJS.Timeout;
+    let fadeOutTimer: NodeJS.Timeout;
+    let clearTimer: NodeJS.Timeout;
+
+    if (clipboardUrl) {
+      setShouldRenderTooltip(true);
+
+      fadeInTimer = setTimeout(() => {
+        setIsTooltipVisible(true);
+      }, 50);
+
+      fadeOutTimer = setTimeout(() => {
+        setIsTooltipVisible(false);
+      }, 30000);
+
+      clearTimer = setTimeout(() => {
+        setShouldRenderTooltip(false);
+        setClipboardUrl(null);
+      }, 31000);
+    } else {
+      setIsTooltipVisible(false);
+      setShouldRenderTooltip(false);
+    }
+
+    return () => {
+      clearTimeout(fadeInTimer);
+      clearTimeout(fadeOutTimer);
+      clearTimeout(clearTimer);
+    };
+  }, [clipboardUrl]);
   const setSelectedFolderId = useFolderStore((s) => s.setSelectedFolderId);
   const selectedFolderId = useFolderStore((s) => s.selectedFolderId);           // 현재 선택된 폴더 ID
   const searchQuery = useFolderStore((s) => s.searchQuery);           // 폴더 검색어 상태
@@ -48,6 +110,38 @@ export default function MyLinksPage() {
     }, 250);
     return () => clearTimeout(handler);
   }, [localSearchQuery, searchQuery, setSearchQuery]);
+
+  // CSS 변수에서 tablet-lg 브레이크포인트를 읽어 px 값으로 변환합니다.
+  // globals.css의 --breakpoint-tablet-lg 값과 항상 동기화됩니다.
+  useEffect(() => {
+    const getTabletLgBreakpoint = (): number => {
+      const raw = getComputedStyle(document.documentElement)
+        .getPropertyValue('--breakpoint-tablet-lg')
+        .trim(); // e.g. "87.5rem"
+      const remValue = parseFloat(raw); // 87.5
+      const rootFontSize = parseFloat(getComputedStyle(document.documentElement).fontSize); // 보통 16px
+      return remValue * rootFontSize; // 1400px
+    };
+
+    const handleResize = () => {
+      const breakpoint = getTabletLgBreakpoint();
+      const isDesktop = window.innerWidth >= breakpoint;
+      const currentPanelState = useUIStore.getState().rightPanelOpen;
+      
+      // 상태가 실제로 변경될 때만 업데이트를 호출하여 무한 렌더링/렉을 예방합니다.
+      if (isDesktop && !currentPanelState) {
+        toggleRightPanel(true);
+      } else if (!isDesktop && currentPanelState) {
+        toggleRightPanel(false);
+      }
+    };
+
+    // 초기 실행
+    handleResize();
+
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, [toggleRightPanel]);
 
   const { data: folders, isLoading: isFoldersLoading, error } = useFolders(memberId); // 전체 폴더 목록 조회
 
@@ -225,7 +319,7 @@ export default function MyLinksPage() {
   return (
     <div className="flex h-full w-full overflow-hidden">
       {/* Main Content Area */}
-      <div className="flex-1 min-w-0 overflow-y-auto px-4 py-2 xl:px-5 xl:py-3 transition-all duration-300 bg-[#fafafa] dark:bg-white/[0.04]">
+      <div className="flex-1 min-w-0 overflow-y-auto px-4 py-2 pb-28 tablet-lg:px-5 tablet-lg:py-3 tablet-lg:pb-4 transition-colors duration-300 bg-[#fafafa] dark:bg-white/[0.04]">
         
         {/* Top Search & Filter Section */}
         <div className="mb-5 flex flex-col items-start bg-transparent">
@@ -249,7 +343,8 @@ export default function MyLinksPage() {
                 onChange={(val) => setSearchScope(val as SearchScope)}
                 options={scopeOptions}
                 className="shrink-0 mr-1 ml-1"
-                panelClassName="w-28"
+                panelClassName="w-28 right-[-12px]"
+                align="right"
                 renderTrigger={({ selectedOption, isOpen, toggle }) => (
                   <button
                     type="button"
@@ -362,7 +457,7 @@ export default function MyLinksPage() {
           <>
             {/* Pinned Folders Top Section - Strictly 5 Columns Desktop */}
             {pinnedFolders.length > 0 && (
-              <div className="mb-5">
+              <div className="mb-10 sm:mb-5">
                 <h2 className="text-xs font-bold text-gray-800 dark:text-gray-100 mb-3 ml-1">Pinned</h2>
                 <div className="grid grid-cols-2 lg:grid-cols-5 gap-2">
                   {pinnedFolders.map((folder, idx) => (
@@ -371,11 +466,14 @@ export default function MyLinksPage() {
                       role="button"
                       tabIndex={0}
                       onClick={() => handleFolderBadgeClick(folder.memberFolderId)}
-                      className={`${PINNED_COLORS[idx % PINNED_COLORS.length]} text-white rounded-lg p-2.5 flex flex-col justify-between h-20 relative overflow-hidden group hover:scale-[1.01] transition-all duration-300 cursor-pointer outline-none ${
+                      className={cn(
+                        PINNED_COLORS[idx % PINNED_COLORS.length],
+                        "text-white rounded-lg p-2.5 flex flex-col justify-between h-20 relative overflow-hidden group hover:scale-[1.01] transition-all duration-300 cursor-pointer outline-none",
                         selectedFolderId === folder.memberFolderId 
                           ? 'ring-2 ring-inset ring-white/60 dark:ring-white/30 shadow-md scale-[1.02]' 
-                          : 'shadow-sm hover:shadow-md'
-                      }`}
+                          : 'shadow-sm hover:shadow-md',
+                        folder.folderType === FOLDER_TYPE.UNORGANIZED && "max-sm:hidden"
+                      )}
                     >
                       <div className="flex justify-between items-start z-10 w-full gap-1">
                         <div className="w-8 h-8 flex items-center justify-center bg-white/20 rounded-md shrink-0">
@@ -386,7 +484,7 @@ export default function MyLinksPage() {
                         </button>
                       </div>
                       <div className="z-10 mt-1 min-w-0 w-full">
-                        <h3 className="font-semibold text-[10px] xl:text-[11px] truncate w-full">{folder.folderName}</h3>
+                        <h3 className="font-semibold text-[10px] tablet-lg:text-[11px] truncate w-full">{folder.folderName}</h3>
                       </div>
                       <div className="absolute -right-4 -bottom-4 w-10 h-10 bg-white/10 rounded-full blur-xl group-hover:scale-150 transition-transform duration-500"></div>
                     </div>
@@ -395,34 +493,87 @@ export default function MyLinksPage() {
               </div>
             )}
 
-            <div className="flex justify-between items-center mb-3 ml-1">
+            <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-2.5 mb-3 ml-1 relative z-30">
               <div className="flex items-center gap-2">
                 <h2 className="text-xs font-bold text-gray-800 dark:text-gray-100">My Folder</h2>
               </div>
               
-              <div className="flex items-center gap-1.5 focus-within:z-20 relative">
+              <div className="flex items-center flex-wrap gap-1.5 focus-within:z-20 relative w-full sm:w-auto justify-start sm:justify-end">
                 <SortDropdown 
                   value={folderSort}
                   onChange={setFolderSort}
                   options={folderSortOptions}
-                  panelClassName="bg-white/78 border-white/70 ring-1 ring-slate-200/60 backdrop-blur-xl shadow-[0_20px_45px_-18px_rgba(15,23,42,0.22),0_12px_24px_-16px_rgba(148,163,184,0.45)] dark:ring-0 dark:backdrop-blur-md"
+                  align="right"
+                  panelClassName="right-[-8px] bg-white/78 border-white/70 ring-1 ring-slate-200/60 backdrop-blur-xl shadow-[0_20px_45px_-18px_rgba(15,23,42,0.22),0_12px_24px_-16px_rgba(148,163,184,0.45)] dark:ring-0 dark:backdrop-blur-md"
                 />
                 <button 
                   type="button"
                   onClick={() => useUIStore.getState().toggleCreateFolderDialog(true)}
-                  className="group flex items-center gap-1 px-2 py-1 border border-gray-200/80 dark:border-white/8 rounded-md text-[10px] font-medium transition-all duration-200 bg-white/50 dark:bg-slate-900/50 text-gray-600 dark:text-white hover:bg-purple-50/50 dark:hover:bg-purple-900/20 hover:border-purple-200/50 dark:hover:border-purple-500/30"
+                  className="hidden tablet-lg:flex group items-center gap-1 px-2 py-1 border border-gray-200/80 dark:border-white/8 rounded-md text-[10px] font-medium transition-all duration-200 bg-white/50 dark:bg-slate-900/50 text-gray-600 dark:text-white hover:bg-purple-50/50 dark:hover:bg-purple-900/20 hover:border-purple-200/50 dark:hover:border-purple-300/50"
                 >
                   <span className="material-symbols-outlined !text-[12px] text-gray-400 dark:text-gray-500 group-hover:text-purple-500 dark:group-hover:text-purple-400 transition-colors leading-none">folder</span>
                   <span>Create Folder</span>
                 </button>
-                <button 
-                  type="button"
-                  onClick={() => useUIStore.getState().toggleSaveLinkDialog(true)}
-                  className="flex items-center space-x-1 text-[10px] font-bold text-white bg-[linear-gradient(135deg,#6d28d9_0%,#8b5cf6_50%,#a78bfa_100%)] hover:opacity-90 border-none rounded-md px-2.5 py-1 transition-all shadow-md shadow-purple-500/20 hover:scale-[1.02]"
-                >
-                  <span className="material-symbols-outlined !text-[12px] !leading-none">add</span>
-                  <span>Save Link</span>
-                </button>
+                <div className="relative hidden tablet-lg:block z-50">
+                  {shouldRenderTooltip && clipboardUrl && (
+                    <button
+                      type="button"
+                      onClick={() => {
+                        toggleSaveLinkDialog(true, clipboardUrl);
+                        setClipboardUrl(null);
+                      }}
+                      className={`absolute -top-14 right-[-8px] z-50 group outline-none transition-all duration-1000 ease-in-out ${
+                        isTooltipVisible 
+                          ? 'opacity-100 translate-y-0 scale-100' 
+                          : 'opacity-0 translate-y-2 scale-95 pointer-events-none'
+                      }`}
+                    >
+                      <div className="relative w-[164px] h-[38px] flex items-center justify-center active:scale-95 transition-transform duration-150">
+                        {/* Background Unified SVG Speech Bubble */}
+                        <svg 
+                          className="absolute -top-[2px] -left-[2px] w-[168px] h-[49px] drop-shadow-[0_12px_36px_rgba(124,58,237,0.3)] dark:drop-shadow-[0_12px_36px_rgba(0,0,0,0.6)] pointer-events-none" 
+                          viewBox="-2 -2 168 49" 
+                          fill="none" 
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          {/* Solid Fill */}
+                          <path 
+                            d="M 19 0 L 145 0 A 19 19 0 0 1 164 19 A 19 19 0 0 1 145 38 L 125 38 C 120.5 38 118 39.5 116 45 C 114 39.5 111.5 38 107 38 L 19 38 A 19 19 0 0 1 0 19 A 19 19 0 0 1 19 0 Z" 
+                            className="fill-white dark:fill-[#0a0a0b] group-hover:fill-violet-50 dark:group-hover:fill-[#1c142c] transition-colors duration-300"
+                          />
+                          {/* Consistent Outer Border */}
+                          <path 
+                            d="M 19 0 L 145 0 A 19 19 0 0 1 164 19 A 19 19 0 0 1 145 38 L 125 38 C 120.5 38 118 39.5 116 45 C 114 39.5 111.5 38 107 38 L 19 38 A 19 19 0 0 1 0 19 A 19 19 0 0 1 19 0 Z" 
+                            className="stroke-violet-200 dark:stroke-[#252528] transition-colors duration-300" 
+                            strokeWidth="2"
+                            strokeLinejoin="round"
+                          />
+                        </svg>
+
+                        {/* Speech Bubble Content */}
+                        <div className="relative z-10 flex items-center gap-2 pl-3.5 pr-4.5">
+                          <div className="relative bg-[linear-gradient(135deg,#7c3aed_0%,#a855f7_100%)] w-5 h-5 rounded-full flex items-center justify-center flex-none overflow-hidden">
+                            <span className="inline-flex h-full w-full items-center justify-center rotate-[-45deg]">
+                              <span className="material-symbols-outlined !text-[12px] !leading-none block text-white font-bold">link</span>
+                            </span>
+                          </div>
+                          <span className="text-xs font-extrabold text-slate-800 dark:text-gray-50 tracking-tight pr-0.5 animate-pulse">Paste copied link</span>
+                        </div>
+                      </div>
+                    </button>
+                  )}
+                  <button 
+                    type="button"
+                    onClick={() => {
+                      toggleSaveLinkDialog(true, clipboardUrl || undefined);
+                      if (clipboardUrl) setClipboardUrl(null);
+                    }}
+                    className="flex items-center space-x-1 text-[10px] font-bold text-white bg-[linear-gradient(135deg,#6d28d9_0%,#8b5cf6_50%,#a78bfa_100%)] hover:opacity-90 border-none rounded-md px-2.5 py-1 transition-all shadow-md shadow-purple-500/20 hover:scale-[1.02]"
+                  >
+                    <span className="material-symbols-outlined !text-[12px] !leading-none">add</span>
+                    <span>Save Link</span>
+                  </button>
+                </div>
               </div>
             </div>
 
@@ -457,6 +608,33 @@ export default function MyLinksPage() {
                 </div>
               )}
 
+              {/* ── 가상 'All Links' 폴더 카드 ── */}
+              <div
+                role="button"
+                tabIndex={0}
+                onClick={() => {
+                  setSelectedFolderId(null);
+                  toggleRightPanel(true);
+                }}
+                className={cn(
+                  "bg-white dark:bg-card-dark rounded-lg p-2.5 border transition-all duration-300 group cursor-pointer h-[90px] flex flex-col justify-between outline-none relative overflow-visible",
+                  selectedFolderId === null && useUIStore.getState().rightPanelOpen
+                    ? "border-purple-500 bg-purple-50/40 dark:border-purple-400 dark:bg-purple-500/10 shadow-sm hover:bg-purple-50/40 dark:hover:bg-purple-500/10"
+                    : "border-gray-200/70 dark:border-white/5 shadow-sm hover:shadow-md hover:border-purple-300 dark:hover:border-white/10 hover:bg-purple-50/30 dark:hover:bg-white/[0.03]"
+                )}
+              >
+                <div className="flex justify-between items-start">
+                  <div className="p-1.5 bg-purple-50 dark:bg-white/5 text-gray-400 dark:text-gray-400 group-hover:dark:text-white transition-colors rounded-md flex items-center justify-center w-8 h-8">
+                    <span className="material-symbols-outlined text-[16px] font-bold">bookmarks</span>
+                  </div>
+                </div>
+                <div>
+                  <h4 className="font-semibold text-[10.5px] text-gray-800 dark:text-white truncate mt-1.5 flex items-center gap-1">
+                    <span>All Links</span>
+                  </h4>
+                </div>
+              </div>
+
               {/* ── 폴더 카드 목록 (백엔드 데이터 반복 렌더링) ── */}
               {processedAllFolders.map((folder) => (
                 <FolderCard key={folder.memberFolderId} folder={folder} />
@@ -465,6 +643,8 @@ export default function MyLinksPage() {
           </>
         )}
       </div>
+
+
 
       {/* Right Sidebar Panel */}
       <RightPanel />

--- a/frontend/src/app/my-links/page.tsx
+++ b/frontend/src/app/my-links/page.tsx
@@ -13,6 +13,7 @@ import { FOLDER_TYPE } from '@/lib/types/folder';
 import { useState, useEffect, useMemo } from 'react';
 import { cn } from '@/lib/utils';
 import { compareFolders } from '@/lib/utils/folderUtils';
+import { motion } from 'framer-motion';
 
 export default function MyLinksPage() {
   const { toggleRightPanel, toggleSaveLinkDialog, saveLinkDialogOpen } = useUIStore();
@@ -445,7 +446,13 @@ export default function MyLinksPage() {
                 </div>
               ) : (
                 processedSearchResultFolders.map((folder) => (
-                  <FolderCard key={folder.memberFolderId} folder={folder} />
+                  <motion.div
+                    key={folder.memberFolderId}
+                    layout="position"
+                    transition={{ type: 'spring', stiffness: 300, damping: 32 }}
+                  >
+                    <FolderCard folder={folder} />
+                  </motion.div>
                 ))
               )}
             </div>
@@ -484,7 +491,7 @@ export default function MyLinksPage() {
                         </button>
                       </div>
                       <div className="z-10 mt-1 min-w-0 w-full">
-                        <h3 className="font-semibold text-[10px] tablet-lg:text-[11px] truncate w-full">{folder.folderName}</h3>
+                        <h3 className="font-semibold text-[10.5px] tablet-lg:text-[11.5px] truncate w-full">{folder.folderName}</h3>
                       </div>
                       <div className="absolute -right-4 -bottom-4 w-10 h-10 bg-white/10 rounded-full blur-xl group-hover:scale-150 transition-transform duration-500"></div>
                     </div>
@@ -609,7 +616,10 @@ export default function MyLinksPage() {
               )}
 
               {/* ── 가상 'All Links' 폴더 카드 ── */}
-              <div
+              <motion.div
+                key="all-links"
+                layout="position"
+                transition={{ type: 'spring', stiffness: 300, damping: 32 }}
                 role="button"
                 tabIndex={0}
                 onClick={() => {
@@ -629,15 +639,21 @@ export default function MyLinksPage() {
                   </div>
                 </div>
                 <div>
-                  <h4 className="font-semibold text-[10.5px] text-gray-800 dark:text-white truncate mt-1.5 flex items-center gap-1">
+                  <h4 className="font-semibold text-[11.5px] text-gray-800 dark:text-white truncate mt-1.5 flex items-center gap-1">
                     <span>All Links</span>
                   </h4>
                 </div>
-              </div>
+              </motion.div>
 
               {/* ── 폴더 카드 목록 (백엔드 데이터 반복 렌더링) ── */}
               {processedAllFolders.map((folder) => (
-                <FolderCard key={folder.memberFolderId} folder={folder} />
+                <motion.div
+                  key={folder.memberFolderId}
+                  layout="position"
+                  transition={{ type: 'spring', stiffness: 300, damping: 32 }}
+                >
+                  <FolderCard folder={folder} />
+                </motion.div>
               ))}
             </div>
           </>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -67,7 +67,12 @@ export default function Home() {
     if (isAuthenticated) {
       router.push("/my-links");
     } else {
-      router.push("/login");
+      // 모바일/태블릿 크기(lg 중단점인 1024px 미만)일 때는 바로 구글 로그인 페이지로 이동
+      if (typeof window !== "undefined" && window.innerWidth < 1024) {
+        window.location.href = buildBackendUrl('/oauth2/authorization/google');
+      } else {
+        router.push("/login");
+      }
     }
   };
 
@@ -79,11 +84,11 @@ export default function Home() {
       <LandingHeader />
 
       <main className="flex-grow">
-        <section className="relative flex min-h-[100dvh] items-center overflow-hidden pt-12 pb-16 lg:pt-20 lg:pb-24 px-6 lg:px-20 bg-background-light dark:bg-background-dark transition-colors duration-300">
+        <section className="relative flex min-h-[100dvh] items-center max-sm:items-start overflow-hidden max-sm:pt-36 max-sm:pb-8 pt-12 pb-16 lg:pt-20 lg:pb-24 px-6 lg:px-20 bg-background-light dark:bg-background-dark transition-colors duration-300">
           <div className="absolute top-0 right-0 -z-10 h-[600px] w-[600px] bg-primary/5 dark:bg-violet-600/15 rounded-full blur-[100px] translate-x-1/3 -translate-y-1/4"></div>
           <div className="absolute bottom-0 left-0 -z-10 h-[400px] w-[400px] bg-primary-light/40 dark:bg-violet-900/40 rounded-full blur-[80px] -translate-x-1/4 translate-y-1/4"></div>
           <div className="w-full mx-auto max-w-6xl">
-            <div className="flex flex-col lg:flex-row justify-between gap-8 lg:items-center">
+            <div className="flex flex-col lg:flex-row justify-between max-sm:gap-2 gap-8 lg:items-center">
               {/* Left Column: Text & Features */}
               <div className="flex flex-col gap-6 lg:w-[50%] lg:pr-10">
                 <div className="space-y-4 text-left">
@@ -123,7 +128,7 @@ export default function Home() {
                   </a>
                 </div>
 
-                <div className="flex flex-col gap-5 border-t border-slate-100 dark:border-white/10 pt-8 mt-4 relative z-10">
+                <div className="flex flex-col gap-5 border-t border-slate-100 dark:border-white/10 pt-8 mt-4 relative z-10 max-lg:hidden">
                   <div className="flex items-center gap-4 group">
                     <div className="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-2xl bg-white dark:bg-violet-500/10 shadow-[0_2px_8px_rgba(0,0,0,0.04)] dark:shadow-none border border-slate-100 dark:border-violet-500/20 text-primary dark:text-violet-300 transition-all duration-500 group-hover:bg-slate-50 dark:group-hover:bg-violet-500/30 group-hover:shadow-[0_8px_25px_rgba(139,92,246,0.15)] group-hover:-translate-y-1 group-hover:ring-2 group-hover:ring-violet-400">
                       <span className="material-symbols-outlined text-[24px] transition-all duration-500 group-hover:text-primary dark:group-hover:text-violet-200 group-hover:scale-110 group-hover:drop-shadow-[0_0_12px_rgba(167,139,250,0.6)]">auto_awesome</span>
@@ -156,13 +161,13 @@ export default function Home() {
                 </div>
               </div>
 
-              {/* Right Column: Animated Card Illustration */}
-              <div className="lg:w-[50%] flex justify-center lg:justify-end mt-12 lg:mt-0">
-                <div className="relative w-full max-w-2xl py-12 sm:py-20 flex justify-center items-center">
+              {/* Right Column: Animated Card Illustration & Mobile Feature List */}
+              <div className="lg:w-[50%] flex flex-col items-center justify-center lg:justify-end max-sm:mt-0 mt-12 lg:mt-0 w-full">
+                <div className="relative w-full max-w-2xl max-sm:py-4 py-12 sm:py-20 flex justify-center items-center">
                   {/* Background decoration */}
                   <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-full aspect-square bg-linear-to-br from-primary/10 to-transparent dark:from-violet-600/10 rounded-full blur-3xl -z-10"></div>
                   
-                  <div className="flex items-center -space-x-12 sm:-space-x-16 relative z-10 scale-90 sm:scale-100">
+                  <div className="flex items-center max-sm:-space-x-8 -space-x-12 sm:-space-x-16 relative z-10 max-sm:scale-75 scale-75 xs:scale-85 sm:scale-100">
                     {/* Left Card */}
                     <div className="h-32 w-44 sm:h-40 sm:w-56 rounded-xl border border-slate-100 dark:border-violet-500/20 bg-white/95 dark:bg-slate-900/90 shadow-[0_0_40px_rgba(139,92,246,0.2)] dark:shadow-violet-900/10 backdrop-blur-md p-4 flex flex-col gap-3 rotate-[-8deg] transition-all hover:rotate-0 hover:scale-110 duration-500 group z-10 hover:border-violet-300 dark:hover:border-violet-500/40 group-hover:shadow-[0_0_80px_rgba(139,92,246,0.4)]">
                       <div className="flex items-center gap-3">
@@ -227,39 +232,43 @@ export default function Home() {
                       </div>
                     </div>
                   </div>
-
-                  {/* 마지막 남은 배경 요소들 주석 처리
-                  <div className="absolute top-10 right-[10%] h-4 w-4 rounded-full bg-blue-400/20 blur-sm animate-pulse"></div>
-                  
-                  <div className={`absolute bottom-[12%] left-[4%] lg:left-[10%] hidden sm:block z-0 transition-opacity duration-1000 pointer-events-none filter blur-[2px] ${mounted ? 'opacity-70 dark:opacity-50 animate-float-soft' : 'opacity-0'}`} style={{ animationDelay: '1s' }}>
-                    <div className="p-2.5 rounded-3xl bg-white/40 dark:bg-slate-800/40 border border-white/40 dark:border-white/10 rotate-[15deg] scale-105 shadow-lg">
-                      <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-violet-400/10 text-violet-500/80">
-                        <span className="material-symbols-outlined text-[28px]">auto_fix_high</span>
-                      </div>
-                    </div>
-                  </div>
-                  */}
-                  
-                  {/* Floating Folder Icon 주석 처리
-                  <div className={`absolute top-[18%] left-[1%] lg:left-[5%] hidden sm:block z-0 transition-opacity duration-1000 pointer-events-none filter blur-[2px] ${mounted ? 'opacity-60 dark:opacity-40 animate-float-soft-slow' : 'opacity-0'}`}>
-                    <div className="p-2.5 rounded-3xl bg-white/40 dark:bg-slate-800/40 border border-white/40 dark:border-white/10 rotate-[-15deg] scale-110 shadow-xl">
-                      <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-amber-400/10 text-amber-500/80">
-                        <span className="material-symbols-outlined text-[32px]">folder_special</span>
-                      </div>
-                    </div>
-                  </div>
-                  */}
-                  
-                  {/* Floating Rocket Icon 주석 처리
-                  <div className={`absolute bottom-[14%] right-[0%] lg:right-[4%] hidden sm:block z-0 transition-opacity duration-1000 pointer-events-none filter blur-[1.5px] ${mounted ? 'opacity-70 dark:opacity-50 animate-float-soft' : 'opacity-0'}`} style={{ animationDelay: '2s' }}>
-                    <div className="p-2.5 rounded-3xl bg-white/50 dark:bg-slate-700/50 border border-white/50 dark:border-blue-400/20 rotate-[12deg] scale-85 shadow-lg">
-                      <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-linear-to-br from-blue-500/20 to-purple-600/20 dark:from-blue-500/30 dark:to-purple-600/30 text-blue-600 dark:text-purple-400">
-                        <span className="material-symbols-outlined text-[32px]">rocket</span>
-                      </div>
-                    </div>
-                  </div>
-                  */}
                 </div>
+
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* Mobile/Tablet Feature List Section (Scroll down to see) */}
+        <section className="lg:hidden bg-background-light dark:bg-background-dark px-6 pb-16 pt-4 relative z-10 border-b border-slate-100/10 dark:border-white/5 transition-colors duration-300">
+          <div className="mx-auto max-w-md w-full flex flex-col gap-5 border-t border-slate-100 dark:border-white/10 pt-8 max-sm:px-2">
+            <div className="flex items-center gap-4 group">
+              <div className="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-2xl bg-white dark:bg-violet-500/10 shadow-[0_2px_8px_rgba(0,0,0,0.04)] dark:shadow-none border border-slate-100 dark:border-violet-500/20 text-primary dark:text-violet-300 transition-all duration-500 group-hover:bg-slate-50 dark:group-hover:bg-violet-500/30 group-hover:shadow-[0_8px_25px_rgba(139,92,246,0.15)] group-hover:-translate-y-1 group-hover:ring-2 group-hover:ring-violet-400">
+                <span className="material-symbols-outlined text-[24px]">auto_awesome</span>
+              </div>
+              <div className="flex flex-col justify-center">
+                <h4 className="font-bold text-text-main dark:text-white text-[15px] tracking-tight mb-0.5">AI 자동 태깅</h4>
+                <p className="text-sm font-medium tracking-tight text-text-sub dark:text-white/60 opacity-80">문서 내용 분석을 통한 지능형 자동 카테고리 분류</p>
+              </div>
+            </div>
+            
+            <div className="flex items-center gap-4 group">
+              <div className="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-2xl bg-white dark:bg-violet-500/10 shadow-[0_2px_8px_rgba(0,0,0,0.04)] dark:shadow-none border border-slate-100 dark:border-violet-500/20 text-primary dark:text-violet-300 transition-all duration-500 group-hover:bg-slate-50 dark:group-hover:bg-violet-500/30 group-hover:shadow-[0_8px_25px_rgba(139,92,246,0.15)] group-hover:-translate-y-1 group-hover:ring-2 group-hover:ring-violet-400">
+                <span className="material-symbols-outlined text-[24px]">folder_open</span>
+              </div>
+              <div className="flex flex-col justify-center">
+                <h4 className="font-bold text-text-main dark:text-white text-[15px] tracking-tight mb-0.5">스마트 폴더 추천</h4>
+                <p className="text-sm font-medium tracking-tight text-text-sub dark:text-white/60 opacity-80">프로젝트 및 팀별 문서를 최적의 구조로 스마트하게 정리</p>
+              </div>
+            </div>
+            
+            <div className="flex items-center gap-4 group">
+              <div className="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-2xl bg-white dark:bg-violet-500/10 shadow-[0_2px_8px_rgba(0,0,0,0.04)] dark:shadow-none border border-slate-100 dark:border-violet-500/20 text-primary dark:text-violet-300 transition-all duration-500 group-hover:bg-slate-50 dark:group-hover:bg-violet-500/30 group-hover:shadow-[0_8px_25px_rgba(139,92,246,0.15)] group-hover:-translate-y-1 group-hover:ring-2 group-hover:ring-violet-400">
+                <span className="material-symbols-outlined text-[24px]">bolt</span>
+              </div>
+              <div className="flex flex-col justify-center">
+                <h4 className="font-bold text-text-main dark:text-white text-[15px] tracking-tight mb-0.5">초고속 검색</h4>
+                <p className="text-sm font-medium tracking-tight text-text-sub dark:text-white/60 opacity-80">수만 개의 자료 속에서 원하는 정보를 찾아내는 0.1초 검색</p>
               </div>
             </div>
           </div>
@@ -411,13 +420,13 @@ export default function Home() {
         */}
       </main>
 
-      <footer className="border-t border-white/5 bg-[#030712] px-6 py-12 lg:px-20 relative z-20 transition-all duration-300">
+      <footer className="border-t border-white/5 bg-[#030712] px-5 py-12 lg:px-20 relative z-20 transition-all duration-300">
         <div className="mx-auto flex max-w-6xl flex-col items-center justify-between gap-8 md:flex-row">
           <div className="flex items-center space-x-2 group transition-opacity">
             <span className="material-symbols-outlined text-3xl text-violet-400 group-hover:scale-110 transition-transform">language</span>
             <span className="text-xl font-bold tracking-tight text-white uppercase sm:normal-case">ReLink</span>
           </div>
-          <div className="flex gap-10 text-sm text-slate-400">
+          <div className="flex flex-wrap justify-center md:justify-start gap-6 md:gap-10 text-sm text-slate-400">
             <a className="hover:text-white transition-colors" href="#">이용약관</a>
             <a className="hover:text-white transition-colors" href="#">개인정보처리방침</a>
             <a className="hover:text-white transition-colors" href="https://relink.featurebase.app/en" target="_blank" rel="noopener noreferrer">문의하기</a>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -67,8 +67,8 @@ export default function Home() {
     if (isAuthenticated) {
       router.push("/my-links");
     } else {
-      // 모바일/태블릿 크기(lg 중단점인 1024px 미만)일 때는 바로 구글 로그인 페이지로 이동
-      if (typeof window !== "undefined" && window.innerWidth < 1024) {
+      // 모바일/태블릿 크기(tablet-lg 중단점인 1400px 미만)일 때는 바로 구글 로그인 페이지로 이동
+      if (typeof window !== "undefined" && window.innerWidth < 1400) {
         window.location.href = buildBackendUrl('/oauth2/authorization/google');
       } else {
         router.push("/login");
@@ -440,7 +440,7 @@ export default function Home() {
       {/* Scroll to Top Button */}
       <button
         onClick={scrollToTop}
-        className={`fixed bottom-7 right-7 z-[60] flex h-10 w-10 items-center justify-center rounded-full border border-white/[0.08] bg-[#050505]/92 text-white shadow-[0_14px_34px_rgba(0,0,0,0.42)] backdrop-blur-xl transition-all duration-500 hover:scale-105 hover:bg-[#000000]/96 hover:shadow-[0_18px_40px_rgba(0,0,0,0.52)] active:scale-95 ${
+        className={`fixed bottom-7 right-7 z-floating flex h-10 w-10 items-center justify-center rounded-full border border-white/[0.08] bg-[#050505]/92 text-white shadow-[0_14px_34px_rgba(0,0,0,0.42)] backdrop-blur-xl transition-all duration-500 hover:scale-105 hover:bg-[#000000]/96 hover:shadow-[0_18px_40px_rgba(0,0,0,0.52)] active:scale-95 ${
           showScrollTop ? "translate-y-0 opacity-100" : "pointer-events-none translate-y-16 opacity-0"
         }`}
         aria-label="맨 위로 가기"

--- a/frontend/src/components/dialogs/CreateFolderDialog.tsx
+++ b/frontend/src/components/dialogs/CreateFolderDialog.tsx
@@ -59,17 +59,17 @@ export function CreateFolderDialog() {
 
   return (
     <Dialog open={createFolderDialogOpen} onOpenChange={toggleCreateFolderDialog}>
-      <DialogContent className="max-sm:!top-auto max-sm:!bottom-0 max-sm:!translate-y-0 max-sm:!max-w-full max-sm:px-0 max-sm:!rounded-t-3xl max-sm:!rounded-b-none max-sm:border-x-0 max-sm:border-b-0 max-sm:pb-8 sm:max-w-md bg-white dark:bg-[#0a0a0b] sm:rounded-[16px] shadow-2xl p-0 overflow-hidden border border-gray-100 dark:border-white/[0.08] !gap-0 [&>button]:hidden max-sm:data-[state=open]:!slide-in-from-bottom-full max-sm:data-[state=closed]:!slide-out-to-bottom-full max-sm:data-[state=open]:!zoom-in-100 max-sm:data-[state=closed]:!zoom-out-100 duration-300">
+      <DialogContent className="max-tablet-lg:!top-auto max-tablet-lg:!bottom-0 max-tablet-lg:!translate-y-0 max-sm:!max-w-full sm:max-w-md max-tablet-lg:max-w-md max-sm:px-0 sm:px-4 max-tablet-lg:px-4 max-tablet-lg:!rounded-t-3xl max-sm:!rounded-b-none sm:rounded-[16px] max-tablet-lg:rounded-[16px] max-tablet-lg:border-x-0 max-tablet-lg:border-b-0 max-tablet-lg:pb-8 tablet-lg:max-w-md bg-white dark:bg-[#0a0a0b] tablet-lg:rounded-[16px] shadow-2xl p-0 overflow-hidden border border-gray-100 dark:border-white/[0.08] !gap-0 [&>button]:hidden max-tablet-lg:data-[state=open]:!slide-in-from-bottom-full max-tablet-lg:data-[state=closed]:!slide-out-to-bottom-full max-tablet-lg:data-[state=open]:!zoom-in-100 max-tablet-lg:data-[state=closed]:!zoom-out-100 duration-300">
         
         {/* Mobile Drag Handle Indicator */}
-        <div className="w-full flex justify-center pt-3 pb-1 sm:hidden bg-white dark:bg-[#0a0a0b]">
+        <div className="w-full flex justify-center pt-3 pb-1 tablet-lg:hidden bg-white dark:bg-[#0a0a0b]">
           <div className="w-10 h-1.5 bg-slate-200 dark:bg-slate-800 rounded-full" />
         </div>
 
         {/* 접근성을 위한 제목 (가독성을 위해 숨김 처리) */}
         <DialogTitle className="sr-only">Create New Folder</DialogTitle>
 
-        <div className="p-6 pt-3 sm:pt-6">
+        <div className="p-6 pt-3 tablet-lg:pt-6">
           {/* 헤더 영역: 제목 및 닫기 버튼 */}
           <div className="flex justify-between items-center mb-6">
             <div className="flex items-center gap-3">
@@ -189,7 +189,7 @@ export function CreateFolderDialog() {
           <button 
             type="button"
             onClick={() => toggleCreateFolderDialog(false)}
-            className="text-sm font-medium text-gray-500 hover:text-gray-800 dark:text-gray-400 dark:hover:text-white transition-colors max-sm:hidden"
+            className="text-sm font-medium text-gray-500 hover:text-gray-800 dark:text-gray-400 dark:hover:text-white transition-colors max-tablet-lg:hidden"
           >
             Cancel
           </button>
@@ -197,7 +197,7 @@ export function CreateFolderDialog() {
             type="button"
             onClick={handleCreateFolder}
             disabled={!folderName.trim() || createFolderMutation.isPending} // 이름이 없거나 생성 중이면 비활성화
-            className="px-5 py-2.5 rounded-xl bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-sm font-semibold shadow-lg shadow-purple-500/30 hover:shadow-purple-500/50 hover:scale-[1.02] transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed max-sm:w-full max-sm:text-center max-sm:py-3.5 max-sm:text-[15px]"
+            className="px-5 py-2.5 rounded-xl bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-sm font-semibold shadow-lg shadow-purple-500/30 hover:shadow-purple-500/50 hover:scale-[1.02] transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed max-tablet-lg:w-full max-tablet-lg:text-center max-tablet-lg:py-3.5 max-tablet-lg:text-[15px]"
           >
             {createFolderMutation.isPending ? 'Creating...' : 'Create Folder'}
           </button>

--- a/frontend/src/components/dialogs/CreateFolderDialog.tsx
+++ b/frontend/src/components/dialogs/CreateFolderDialog.tsx
@@ -59,12 +59,17 @@ export function CreateFolderDialog() {
 
   return (
     <Dialog open={createFolderDialogOpen} onOpenChange={toggleCreateFolderDialog}>
-      <DialogContent className="sm:max-w-md bg-white dark:bg-[#0a0a0b] rounded-[16px] shadow-2xl p-0 overflow-hidden border border-gray-100 dark:border-white/[0.08] !gap-0 [&>button]:hidden">
+      <DialogContent className="max-sm:!top-auto max-sm:!bottom-0 max-sm:!translate-y-0 max-sm:!max-w-full max-sm:px-0 max-sm:!rounded-t-3xl max-sm:!rounded-b-none max-sm:border-x-0 max-sm:border-b-0 max-sm:pb-8 sm:max-w-md bg-white dark:bg-[#0a0a0b] sm:rounded-[16px] shadow-2xl p-0 overflow-hidden border border-gray-100 dark:border-white/[0.08] !gap-0 [&>button]:hidden max-sm:data-[state=open]:!slide-in-from-bottom-full max-sm:data-[state=closed]:!slide-out-to-bottom-full max-sm:data-[state=open]:!zoom-in-100 max-sm:data-[state=closed]:!zoom-out-100 duration-300">
         
+        {/* Mobile Drag Handle Indicator */}
+        <div className="w-full flex justify-center pt-3 pb-1 sm:hidden bg-white dark:bg-[#0a0a0b]">
+          <div className="w-10 h-1.5 bg-slate-200 dark:bg-slate-800 rounded-full" />
+        </div>
+
         {/* 접근성을 위한 제목 (가독성을 위해 숨김 처리) */}
         <DialogTitle className="sr-only">Create New Folder</DialogTitle>
 
-        <div className="p-6">
+        <div className="p-6 pt-3 sm:pt-6">
           {/* 헤더 영역: 제목 및 닫기 버튼 */}
           <div className="flex justify-between items-center mb-6">
             <div className="flex items-center gap-3">
@@ -184,7 +189,7 @@ export function CreateFolderDialog() {
           <button 
             type="button"
             onClick={() => toggleCreateFolderDialog(false)}
-            className="text-sm font-medium text-gray-500 hover:text-gray-800 dark:text-gray-400 dark:hover:text-white transition-colors"
+            className="text-sm font-medium text-gray-500 hover:text-gray-800 dark:text-gray-400 dark:hover:text-white transition-colors max-sm:hidden"
           >
             Cancel
           </button>
@@ -192,7 +197,7 @@ export function CreateFolderDialog() {
             type="button"
             onClick={handleCreateFolder}
             disabled={!folderName.trim() || createFolderMutation.isPending} // 이름이 없거나 생성 중이면 비활성화
-            className="px-5 py-2.5 rounded-xl bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-sm font-semibold shadow-lg shadow-purple-500/30 hover:shadow-purple-500/50 hover:scale-[1.02] transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed"
+            className="px-5 py-2.5 rounded-xl bg-gradient-to-r from-purple-600 to-indigo-600 text-white text-sm font-semibold shadow-lg shadow-purple-500/30 hover:shadow-purple-500/50 hover:scale-[1.02] transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed max-sm:w-full max-sm:text-center max-sm:py-3.5 max-sm:text-[15px]"
           >
             {createFolderMutation.isPending ? 'Creating...' : 'Create Folder'}
           </button>

--- a/frontend/src/components/dialogs/SaveLinkDialog.tsx
+++ b/frontend/src/components/dialogs/SaveLinkDialog.tsx
@@ -32,11 +32,11 @@ const styles = {
   tagChipSelected: "bg-violet-50 dark:bg-purple-900/40 text-violet-700 dark:text-purple-300 border-violet-200 dark:border-purple-700 shadow-sm font-semibold",
   tagChipExisting: "text-[#1e293b] dark:text-gray-300 border-slate-200 dark:border-white/10 hover:bg-slate-50 dark:hover:bg-slate-700 hover:border-slate-300 dark:hover:border-white/20",
   tagAddTrigger: "text-[11px] px-2.5 py-1 rounded-full bg-white dark:bg-slate-800 border border-dashed border-slate-300 dark:border-white/15 text-slate-500 dark:text-gray-400 hover:border-violet-500 dark:hover:border-purple-400 hover:text-violet-600 dark:hover:text-purple-400 transition-all cursor-pointer flex items-center gap-1 min-h-[26px] w-fit relative z-30 shadow-sm",
-  folderTile: "relative flex flex-col items-center justify-center p-3 rounded-xl border border-[#e2e8f0] dark:border-white/10 bg-white dark:bg-slate-800/60 backdrop-blur-sm cursor-pointer transition-all hover:border-violet-300 dark:hover:border-purple-500/50 hover:bg-slate-50/50 dark:hover:bg-slate-700 text-center gap-1.5 shadow-sm",
+  folderTile: "relative flex flex-col items-center justify-center p-3 max-sm:p-2.5 rounded-xl border border-[#e2e8f0] dark:border-white/10 bg-white dark:bg-slate-800/60 backdrop-blur-sm cursor-pointer transition-all hover:border-violet-300 dark:hover:border-purple-500/50 hover:bg-slate-50/50 dark:hover:bg-slate-700 text-center gap-1.5 max-sm:gap-1 shadow-sm",
   folderTileActive: "border-violet-500 dark:border-purple-500 ring-1 ring-violet-500 dark:ring-purple-500 bg-white dark:bg-slate-800 text-violet-900 dark:text-purple-300 shadow-[0_0_15px_rgba(124,58,237,0.15)]",
   matchBadge: `absolute -top-2 -right-1.5 ${theme.premiumGradient} text-white text-[9px] font-bold px-1.5 py-[1px] rounded-full shadow-md z-10`,
-  btnGradient: "bg-[linear-gradient(135deg,#7c3aed_0%,#a855f7_100%)] hover:opacity-95 text-white shadow-md shadow-violet-500/20 dark:shadow-purple-900/30",
-  sectionContainer: "bg-gray-50/80 dark:bg-slate-800/50 dark:backdrop-blur-md rounded-2xl p-3 border border-gray-100/50 dark:border-white/[0.05]"
+  btnGradient: "bg-gradient-to-r from-purple-600 to-indigo-600 hover:opacity-95 text-white shadow-lg shadow-purple-500/30 hover:shadow-purple-500/50",
+  sectionContainer: "bg-gray-50/80 dark:bg-slate-800/50 dark:backdrop-blur-md rounded-2xl p-3 max-sm:p-2.5 border border-gray-100/50 dark:border-white/[0.05]"
 };
 
 /**
@@ -44,7 +44,7 @@ const styles = {
  */
 export function SaveLinkDialog() {
   // 전역 UI 상태 (다이얼로그 열림/닫힘)
-  const { saveLinkDialogOpen, toggleSaveLinkDialog } = useUIStore();
+  const { saveLinkDialogOpen, saveLinkDefaultUrl, toggleSaveLinkDialog } = useUIStore();
 
   // --- UI 전용 상태 (태그 팝오버, 입력값 등) ---
   const [tagInput, setTagInput] = useState('');                    // 태그 검색어
@@ -111,8 +111,7 @@ export function SaveLinkDialog() {
   }, [url]);
 
   
-  // --- UI 전용 상태 추가 (클립보드 추천 및 파비콘 폴백) ---
-  const [clipboardUrl, setClipboardUrl] = useState<string | null>(null);
+  // --- UI 전용 상태 추가 (파비콘 폴백) ---
   const [faviconFallbackStep, setFaviconFallbackStep] = useState<'google' | 'direct' | 'failed'>('google');
   const [faviconVisible, setFaviconVisible] = useState(false);
   
@@ -127,24 +126,12 @@ export function SaveLinkDialog() {
     return null;
   })();
 
-  // --- 팝업이 열고 닫힐 때마다 모든 입력 상태 초기화 및 클립보드 감지 ---
+  // --- 팝업이 열고 닫힐 때마다 모든 입력 상태 초기화 ---
   useEffect(() => {
     if (saveLinkDialogOpen) {
-      // 팝업이 열릴 때: 클립보드에 URL이 있는지 한 번만 확인
-      const timerId = setTimeout(async () => {
-        if (typeof navigator === 'undefined' || !navigator.clipboard) return;
-        try {
-          // 브라우저 정책상 사용자 권한 프롬프트가 발생할 수 있습니다.
-          const text = await navigator.clipboard.readText();
-          if (text && (text.startsWith('http://') || text.startsWith('https://'))) {
-            setClipboardUrl(text);
-          }
-        } catch (err) {
-          // 권한 거부 등의 에러는 무시
-          console.warn('Clipboard read error (auto-paste):', err);
-        }
-      }, 150);
-      return () => clearTimeout(timerId);
+      if (saveLinkDefaultUrl) {
+        setUrl(saveLinkDefaultUrl);
+      }
     } else {
       // 팝업이 닫힐 때: 모든 입력 상태 초기화
       setOpenFolderBrowser(false);
@@ -158,9 +145,8 @@ export function SaveLinkDialog() {
       setIsCreatingNewTag(false);
       setAiSuggestedTags(new Set());
       setPendingNewFolderName(null);
-      setClipboardUrl(null);
     }
-  }, [saveLinkDialogOpen]); // 내부 상태(url 등) 의존성 제어
+  }, [saveLinkDialogOpen, saveLinkDefaultUrl]); // 내부 상태(url 등) 의존성 제어
 
   // (커스텀 위치 계산 및 외부 클릭 로직 제거됨 - Popover로 대체)
 
@@ -368,17 +354,22 @@ export function SaveLinkDialog() {
         기존 shadcn 다이얼로그의 배경/패딩, 자체 닫기버튼(&>button:hidden) 무력화 
         투명 배경 위에서 우리의 커스텀 UI 박스(z-10 bg-white rounded-2xl...)가 완전히 덮도록 구성
       */}
-      <DialogContent className="sm:max-w-[540px] sm:left-[calc(50%+90px)] p-0 bg-transparent border-0 shadow-none [&>button]:hidden overflow-visible">
+      <DialogContent className="max-sm:!top-auto max-sm:!bottom-0 max-sm:!translate-y-0 max-sm:!max-w-full max-sm:px-0 max-sm:!rounded-none sm:max-w-[540px] sm:left-1/2 tablet-lg:left-[calc(50%+90px)] p-0 bg-transparent border-0 shadow-none [&>button]:hidden overflow-visible max-sm:data-[state=open]:!slide-in-from-bottom-full max-sm:data-[state=closed]:!slide-out-to-bottom-full max-sm:data-[state=open]:!zoom-in-100 max-sm:data-[state=closed]:!zoom-out-100 duration-300">
         
-        <div className={`relative z-[60] w-full max-w-[540px] bg-white dark:bg-[#0a0a0b] rounded-2xl ${theme.softModalShadow} border border-slate-100 dark:border-white/[0.08] overflow-visible mx-auto`}>
+        <div className={`relative z-[60] w-full max-sm:flex max-sm:flex-col max-sm:h-[72vh] max-sm:max-h-[72vh] max-sm:max-w-full max-sm:rounded-t-[32px] max-sm:rounded-b-none max-sm:border-x-0 max-sm:border-b-0 max-sm:overflow-hidden sm:max-w-[540px] bg-white dark:bg-[#0a0a0b] sm:rounded-2xl ${theme.softModalShadow} border border-slate-100 dark:border-white/[0.08] overflow-visible mx-auto`}>
           
+          {/* Mobile Drag Handle Indicator */}
+          <div className="w-full flex-none flex justify-center pt-3 pb-2 sm:hidden bg-white dark:bg-[#0a0a0b] z-20">
+            <div className="w-12 h-1.5 bg-slate-200 dark:bg-slate-700/50 rounded-full" />
+          </div>
+
           {/* Header & Close */}
-          <div className="relative flex items-center justify-between px-5 pt-5 pb-2 z-10">
+          <div className="relative flex items-center justify-between px-5 max-sm:px-6 pt-5 max-sm:pt-2 pb-2 max-sm:pb-4 z-10 max-sm:z-20 max-sm:flex-none max-sm:bg-white max-sm:dark:bg-[#0a0a0b] max-sm:border-b max-sm:border-slate-100 max-sm:dark:border-white/[0.05]">
             <DialogTitle className={`text-lg font-extrabold ${theme.charcoal} tracking-tight flex items-center gap-2.5`}>
               <div className={`${theme.premiumGradient} p-1.5 rounded-lg flex items-center justify-center`}>
                 <span className="material-symbols-outlined text-white !text-[18px] fill-1">bookmark</span>
               </div>
-              Save to Workspace
+              Save Link
             </DialogTitle>
             <DialogDescription className="sr-only">Save a new link to your workspace with AI assistance</DialogDescription>
             <button 
@@ -389,7 +380,8 @@ export function SaveLinkDialog() {
             </button>
           </div>
 
-          <div className="relative px-5 pb-5 space-y-3 mt-3 z-10">
+          {/* Main Scrollable Area */}
+          <div className="relative px-5 max-sm:px-5 pb-5 max-sm:pb-0 space-y-3 max-sm:space-y-4 mt-3 max-sm:mt-0 z-10 max-sm:flex-1 max-sm:overflow-y-auto max-sm:custom-scrollbar">
             
             {/* URL Input */}
             <div className={`${styles.sectionContainer} space-y-1.5`}>
@@ -437,40 +429,6 @@ export function SaveLinkDialog() {
                   )}
                 </div>
                 <div className="relative flex-1">
-                  {/* 클립보드 자동 인식 - 초미니멀 액션 칩 UI */}
-                  {clipboardUrl && !url && (
-                    <button
-                      type="button"
-                      onClick={() => { setUrl(clipboardUrl); setClipboardUrl(null); }}
-                      className="absolute -top-8 right-0 animate-in fade-in zoom-in-95 slide-in-from-top-2 duration-300 z-20 group outline-none"
-                    >
-                      <div className="bg-white/95 dark:bg-[#0a0a0b]/95 backdrop-blur-xl border border-violet-100 dark:border-white/[0.08] rounded-full shadow-[0_12px_24px_-8px_rgba(124,58,237,0.3)] flex items-center gap-2.5 px-3.5 py-2 whitespace-nowrap transition-all hover:bg-violet-50 dark:hover:bg-purple-900/20 active:scale-95">
-                        <div className={`${styles.btnGradient} w-5 h-5 rounded-full flex items-center justify-center flex-none overflow-hidden shadow-sm shadow-violet-500/20`}>
-                          <span className="inline-flex h-full w-full items-center justify-center rotate-[-45deg] translate-x-[0.25px]">
-                            <span className="material-symbols-outlined !text-[13px] !leading-none block text-white font-bold">link</span>
-                          </span>
-                        </div>
-                        <span className="text-[11px] font-bold text-slate-700 dark:text-gray-100 tracking-tight pr-1">Paste copied link</span>
-                      </div>
-                      {/* 부드럽고 존재감 있는 곡선형 SVG 꼬리표 - 크기 확대 및 실루엣 최적화 */}
-                      <svg 
-                        className="absolute -bottom-[6px] right-4 w-[18px] h-[7px]" 
-                        viewBox="0 0 18 7" 
-                        fill="none" 
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path 
-                          d="M0 0C4.5 0 7 1.5 9 7C11 1.5 13.5 0 18 0Z" 
-                          className="fill-white/95 dark:fill-[#0a0a0b]/95 group-hover:fill-violet-50 dark:group-hover:fill-purple-900/20 transition-colors"
-                        />
-                        <path 
-                          d="M0 0C4.5 0 7 1.5 9 7C11 1.5 13.5 0 18 0" 
-                          className="stroke-violet-100 dark:stroke-white/[0.08] transition-colors" 
-                          strokeWidth="1"
-                        />
-                      </svg>
-                    </button>
-                  )}
                   <input
                     className={`${styles.minimalInput} w-full`}
                     type="text"
@@ -489,7 +447,7 @@ export function SaveLinkDialog() {
               )}
             </div>
 
-            {/* Title Input (새로 추가) */}
+            {/* Title Input */}
             <div className={`${styles.sectionContainer} space-y-1.5`}>
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-1.5">
@@ -515,7 +473,7 @@ export function SaveLinkDialog() {
             </div>
 
             {/* AI Analysis Button */}
-            <div className="flex justify-center w-full">
+            <div className="flex justify-center w-full max-sm:py-1">
               <button
                 onClick={handleAiAnalysis}
                 disabled={!url.trim() || !(url.startsWith('http://') || url.startsWith('https://')) || analyzeLinkMutation.isPending}
@@ -536,7 +494,7 @@ export function SaveLinkDialog() {
             </div>
 
             {/* Folder Selection */}
-            <div className={`${styles.sectionContainer} space-y-3`}>
+            <div className={`${styles.sectionContainer} space-y-3 max-sm:space-y-2`}>
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-1.5">
                   <span className={`material-symbols-outlined !text-[12px] opacity-100 ${theme.accentPurple}`}>folder</span>
@@ -861,19 +819,19 @@ export function SaveLinkDialog() {
             </div>
 
             {/* Footer Buttons */}
-            <div className="flex items-center justify-end gap-3 px-6 py-5 mt-2">
+            <div className="flex items-center justify-end gap-3 px-6 max-sm:px-6 py-5 max-sm:py-4 mt-2 max-sm:mt-0 max-sm:-mx-5 max-sm:sticky max-sm:bottom-0 max-sm:bg-white max-sm:dark:bg-[#0a0a0b] max-sm:border-t max-sm:border-slate-100 max-sm:dark:border-white/[0.05] max-sm:z-20 max-sm:pb-safe">
               <button 
                 onClick={() => toggleSaveLinkDialog(false)} 
-                className="text-xs text-slate-400 dark:text-slate-500 hover:text-slate-700 dark:hover:text-slate-300 transition-colors font-medium px-2 py-1"
+                className="text-xs max-sm:hidden text-slate-400 dark:text-slate-500 hover:text-slate-700 dark:hover:text-slate-300 transition-colors font-medium px-2 py-1"
               >
                 Cancel
               </button>
               <button
                 onClick={handleSave}
                 disabled={!url.trim() || !(url.startsWith('http://') || url.startsWith('https://')) || createBookmarkMutation.isPending || createFolderMutation.isPending || isFoldersLoading}
-                className={`${styles.btnGradient} text-xs font-bold px-6 py-2.5 rounded-xl transition-all flex items-center gap-2 transform hover:-translate-y-0.5 active:translate-y-0 disabled:opacity-50 disabled:cursor-not-allowed shadow-lg`}
+                className={`${styles.btnGradient} text-xs max-sm:text-[15px] font-bold px-6 max-sm:w-full py-2.5 max-sm:py-3.5 rounded-xl transition-all flex justify-center items-center gap-2 transform hover:-translate-y-0.5 active:translate-y-0 disabled:opacity-50 disabled:cursor-not-allowed shadow-lg max-sm:shadow-[0_4px_12px_rgba(124,58,237,0.2)]`}
               >
-                {(createBookmarkMutation.isPending || createFolderMutation.isPending) ? 'Saving...' : 'Save to Workspace'}
+                {(createBookmarkMutation.isPending || createFolderMutation.isPending) ? 'Saving...' : 'Save Link'}
               </button>
             </div>
 

--- a/frontend/src/components/dialogs/SaveLinkDialog.tsx
+++ b/frontend/src/components/dialogs/SaveLinkDialog.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import Image from 'next/image';
-import { useState, useEffect, useRef } from 'react';
-import { createPortal } from 'react-dom';
+import { useState, useEffect } from 'react';
 import { useUIStore } from '@/lib/store/uiStore';
 import { Dialog, DialogContent, DialogTitle, DialogDescription } from '@/components/ui/dialog';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
@@ -406,13 +405,9 @@ export function SaveLinkDialog() {
                         const img = e.currentTarget;
                         // 구글 파비콘 API는 파비콘이 없을 경우 16x16 크기의 기본 지구본 이미지를 200 OK로 반환.
                         // 이를 감지하여 실패로 간주하고 폴백(직접 호출)을 실행.
-                        if (img.naturalWidth === 16 && img.naturalHeight === 16) {
+                        if (faviconFallbackStep === 'google' && img.naturalWidth === 16 && img.naturalHeight === 16) {
                           setFaviconVisible(false);
-                          if (faviconFallbackStep === 'google') {
-                            setFaviconFallbackStep('direct');
-                          } else {
-                            setFaviconFallbackStep('failed');
-                          }
+                          setFaviconFallbackStep('direct');
                         } else {
                           setFaviconVisible(true); // 정상 파비콘일 때만 서서히 표시
                         }

--- a/frontend/src/components/dialogs/SaveLinkDialog.tsx
+++ b/frontend/src/components/dialogs/SaveLinkDialog.tsx
@@ -32,11 +32,11 @@ const styles = {
   tagChipSelected: "bg-violet-50 dark:bg-purple-900/40 text-violet-700 dark:text-purple-300 border-violet-200 dark:border-purple-700 shadow-sm font-semibold",
   tagChipExisting: "text-[#1e293b] dark:text-gray-300 border-slate-200 dark:border-white/10 hover:bg-slate-50 dark:hover:bg-slate-700 hover:border-slate-300 dark:hover:border-white/20",
   tagAddTrigger: "text-[11px] px-2.5 py-1 rounded-full bg-white dark:bg-slate-800 border border-dashed border-slate-300 dark:border-white/15 text-slate-500 dark:text-gray-400 hover:border-violet-500 dark:hover:border-purple-400 hover:text-violet-600 dark:hover:text-purple-400 transition-all cursor-pointer flex items-center gap-1 min-h-[26px] w-fit relative z-30 shadow-sm",
-  folderTile: "relative flex flex-col items-center justify-center p-3 max-sm:p-2.5 rounded-xl border border-[#e2e8f0] dark:border-white/10 bg-white dark:bg-slate-800/60 backdrop-blur-sm cursor-pointer transition-all hover:border-violet-300 dark:hover:border-purple-500/50 hover:bg-slate-50/50 dark:hover:bg-slate-700 text-center gap-1.5 max-sm:gap-1 shadow-sm",
+  folderTile: "relative flex flex-col items-center justify-center p-3 max-tablet-lg:p-2.5 rounded-xl border border-[#e2e8f0] dark:border-white/10 bg-white dark:bg-slate-800/60 backdrop-blur-sm cursor-pointer transition-all hover:border-violet-300 dark:hover:border-purple-500/50 hover:bg-slate-50/50 dark:hover:bg-slate-700 text-center gap-1.5 max-tablet-lg:gap-1 shadow-sm",
   folderTileActive: "border-violet-500 dark:border-purple-500 ring-1 ring-violet-500 dark:ring-purple-500 bg-white dark:bg-slate-800 text-violet-900 dark:text-purple-300 shadow-[0_0_15px_rgba(124,58,237,0.15)]",
   matchBadge: `absolute -top-2 -right-1.5 ${theme.premiumGradient} text-white text-[9px] font-bold px-1.5 py-[1px] rounded-full shadow-md z-10`,
   btnGradient: "bg-gradient-to-r from-purple-600 to-indigo-600 hover:opacity-95 text-white shadow-lg shadow-purple-500/30 hover:shadow-purple-500/50",
-  sectionContainer: "bg-gray-50/80 dark:bg-slate-800/50 dark:backdrop-blur-md rounded-2xl p-3 max-sm:p-2.5 border border-gray-100/50 dark:border-white/[0.05]"
+  sectionContainer: "bg-gray-50/80 dark:bg-slate-800/50 dark:backdrop-blur-md rounded-2xl p-3 max-tablet-lg:p-2.5 border border-gray-100/50 dark:border-white/[0.05]"
 };
 
 /**
@@ -354,17 +354,17 @@ export function SaveLinkDialog() {
         기존 shadcn 다이얼로그의 배경/패딩, 자체 닫기버튼(&>button:hidden) 무력화 
         투명 배경 위에서 우리의 커스텀 UI 박스(z-10 bg-white rounded-2xl...)가 완전히 덮도록 구성
       */}
-      <DialogContent className="max-sm:!top-auto max-sm:!bottom-0 max-sm:!translate-y-0 max-sm:!max-w-full max-sm:px-0 max-sm:!rounded-none sm:max-w-[540px] sm:left-1/2 tablet-lg:left-[calc(50%+90px)] p-0 bg-transparent border-0 shadow-none [&>button]:hidden overflow-visible max-sm:data-[state=open]:!slide-in-from-bottom-full max-sm:data-[state=closed]:!slide-out-to-bottom-full max-sm:data-[state=open]:!zoom-in-100 max-sm:data-[state=closed]:!zoom-out-100 duration-300">
+      <DialogContent className="max-tablet-lg:!top-auto max-tablet-lg:!bottom-0 max-tablet-lg:!translate-y-0 max-sm:!max-w-full sm:max-w-[540px] max-tablet-lg:max-w-[540px] max-sm:px-0 sm:px-4 max-tablet-lg:px-4 max-sm:!rounded-none sm:!rounded-t-[32px] max-tablet-lg:!rounded-t-[32px] tablet-lg:max-w-[540px] tablet-lg:left-[calc(50%+90px)] p-0 bg-transparent border-0 shadow-none [&>button]:hidden overflow-visible max-tablet-lg:data-[state=open]:!slide-in-from-bottom-full max-tablet-lg:data-[state=closed]:!slide-out-to-bottom-full max-tablet-lg:data-[state=open]:!zoom-in-100 max-tablet-lg:data-[state=closed]:!zoom-out-100 duration-300">
         
-        <div className={`relative z-[60] w-full max-sm:flex max-sm:flex-col max-sm:h-[72vh] max-sm:max-h-[72vh] max-sm:max-w-full max-sm:rounded-t-[32px] max-sm:rounded-b-none max-sm:border-x-0 max-sm:border-b-0 max-sm:overflow-hidden sm:max-w-[540px] bg-white dark:bg-[#0a0a0b] sm:rounded-2xl ${theme.softModalShadow} border border-slate-100 dark:border-white/[0.08] overflow-visible mx-auto`}>
+        <div className={`relative z-dialog w-full max-tablet-lg:flex max-tablet-lg:flex-col max-tablet-lg:h-[72vh] max-tablet-lg:max-h-[72vh] max-sm:max-w-full sm:max-w-[540px] max-tablet-lg:max-w-[540px] max-sm:rounded-t-[32px] sm:rounded-2xl max-tablet-lg:rounded-2xl max-sm:rounded-b-none max-tablet-lg:border-x-0 max-tablet-lg:border-b-0 max-tablet-lg:overflow-hidden tablet-lg:max-w-[540px] bg-white dark:bg-[#0a0a0b] tablet-lg:rounded-2xl ${theme.softModalShadow} border border-slate-100 dark:border-white/[0.08] overflow-visible mx-auto`}>
           
           {/* Mobile Drag Handle Indicator */}
-          <div className="w-full flex-none flex justify-center pt-3 pb-2 sm:hidden bg-white dark:bg-[#0a0a0b] z-20">
+          <div className="w-full flex-none flex justify-center pt-3 pb-2 tablet-lg:hidden bg-white dark:bg-[#0a0a0b] z-20">
             <div className="w-12 h-1.5 bg-slate-200 dark:bg-slate-700/50 rounded-full" />
           </div>
 
           {/* Header & Close */}
-          <div className="relative flex items-center justify-between px-5 max-sm:px-6 pt-5 max-sm:pt-2 pb-2 max-sm:pb-4 z-10 max-sm:z-20 max-sm:flex-none max-sm:bg-white max-sm:dark:bg-[#0a0a0b] max-sm:border-b max-sm:border-slate-100 max-sm:dark:border-white/[0.05]">
+          <div className="relative flex items-center justify-between px-5 max-tablet-lg:px-6 pt-5 max-tablet-lg:pt-2 pb-2 max-tablet-lg:pb-4 z-10 max-tablet-lg:z-20 max-tablet-lg:flex-none max-tablet-lg:bg-white max-tablet-lg:dark:bg-[#0a0a0b] max-tablet-lg:border-b max-tablet-lg:border-slate-100 max-tablet-lg:dark:border-white/[0.05]">
             <DialogTitle className={`text-lg font-extrabold ${theme.charcoal} tracking-tight flex items-center gap-2.5`}>
               <div className={`${theme.premiumGradient} p-1.5 rounded-lg flex items-center justify-center`}>
                 <span className="material-symbols-outlined text-white !text-[18px] fill-1">bookmark</span>
@@ -381,7 +381,7 @@ export function SaveLinkDialog() {
           </div>
 
           {/* Main Scrollable Area */}
-          <div className="relative px-5 max-sm:px-5 pb-5 max-sm:pb-0 space-y-3 max-sm:space-y-4 mt-3 max-sm:mt-0 z-10 max-sm:flex-1 max-sm:overflow-y-auto max-sm:custom-scrollbar">
+          <div className="relative px-5 max-tablet-lg:px-5 pb-5 max-tablet-lg:pb-0 space-y-3 max-tablet-lg:space-y-4 mt-3 max-tablet-lg:mt-0 z-10 max-tablet-lg:flex-1 max-tablet-lg:overflow-y-auto max-tablet-lg:custom-scrollbar">
             
             {/* URL Input */}
             <div className={`${styles.sectionContainer} space-y-1.5`}>
@@ -473,7 +473,7 @@ export function SaveLinkDialog() {
             </div>
 
             {/* AI Analysis Button */}
-            <div className="flex justify-center w-full max-sm:py-1">
+            <div className="flex justify-center w-full max-tablet-lg:py-1">
               <button
                 onClick={handleAiAnalysis}
                 disabled={!url.trim() || !(url.startsWith('http://') || url.startsWith('https://')) || analyzeLinkMutation.isPending}
@@ -494,7 +494,7 @@ export function SaveLinkDialog() {
             </div>
 
             {/* Folder Selection */}
-            <div className={`${styles.sectionContainer} space-y-3 max-sm:space-y-2`}>
+            <div className={`${styles.sectionContainer} space-y-3 max-tablet-lg:space-y-2`}>
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-1.5">
                   <span className={`material-symbols-outlined !text-[12px] opacity-100 ${theme.accentPurple}`}>folder</span>
@@ -563,7 +563,7 @@ export function SaveLinkDialog() {
                     </PopoverTrigger>
                     
                     <PopoverContent 
-                      className="w-[--radix-popover-trigger-width] p-0 bg-white dark:bg-[#1c1c1e] rounded-xl shadow-[0_10px_40px_-10px_rgba(0,0,0,0.25)] dark:shadow-2xl border border-slate-200 dark:border-gray-800 z-[110] overflow-hidden animate-in fade-in slide-in-from-top-1 duration-200"
+                      className="w-[--radix-popover-trigger-width] p-0 bg-white dark:bg-[#1c1c1e] rounded-xl shadow-[0_10px_40px_-10px_rgba(0,0,0,0.25)] dark:shadow-2xl border border-slate-200 dark:border-gray-800 z-popover overflow-hidden animate-in fade-in slide-in-from-top-1 duration-200"
                       align="start"
                       sideOffset={6}
                     >
@@ -673,7 +673,7 @@ export function SaveLinkDialog() {
                       value={newTagInputValue}
                       onChange={(e) => setNewTagInputValue(e.target.value)}
                       placeholder="Type tag..."
-                      className="text-[11px] outline-none text-[#1e293b] dark:text-gray-200 w-16 sm:w-20 bg-transparent placeholder-slate-400 font-medium"
+                      className="text-[11px] outline-none text-[#1e293b] dark:text-gray-200 w-16 tablet-lg:w-20 bg-transparent placeholder-slate-400 font-medium"
                       autoFocus
                       onKeyDown={(e) => {
                         if (e.key === 'Enter' && newTagInputValue.trim()) {
@@ -718,7 +718,7 @@ export function SaveLinkDialog() {
                       </button>
                     </PopoverTrigger>
                     <PopoverContent 
-                      className="w-[200px] p-2 bg-white dark:bg-[#1c1c1e] rounded-xl shadow-[0_10px_40px_-10px_rgba(0,0,0,0.2)] dark:shadow-2xl border border-slate-200 dark:border-gray-800 z-[100]" 
+                      className="w-[200px] p-2 bg-white dark:bg-[#1c1c1e] rounded-xl shadow-[0_10px_40px_-10px_rgba(0,0,0,0.2)] dark:shadow-2xl border border-slate-200 dark:border-gray-800 z-popover" 
                       align="start" 
                       side="bottom" // [수정] 아래로 여는 것을 선호하지만
                       sideOffset={8}
@@ -819,17 +819,17 @@ export function SaveLinkDialog() {
             </div>
 
             {/* Footer Buttons */}
-            <div className="flex items-center justify-end gap-3 px-6 max-sm:px-6 py-5 max-sm:py-4 mt-2 max-sm:mt-0 max-sm:-mx-5 max-sm:sticky max-sm:bottom-0 max-sm:bg-white max-sm:dark:bg-[#0a0a0b] max-sm:border-t max-sm:border-slate-100 max-sm:dark:border-white/[0.05] max-sm:z-20 max-sm:pb-safe">
+            <div className="flex items-center justify-end gap-3 px-6 max-tablet-lg:px-6 py-5 max-tablet-lg:py-4 mt-2 max-tablet-lg:mt-0 max-tablet-lg:-mx-5 max-tablet-lg:sticky max-tablet-lg:bottom-0 max-tablet-lg:bg-white max-tablet-lg:dark:bg-[#0a0a0b] max-tablet-lg:border-t max-tablet-lg:border-slate-100 max-tablet-lg:dark:border-white/[0.05] max-tablet-lg:z-20 max-tablet-lg:pb-safe">
               <button 
                 onClick={() => toggleSaveLinkDialog(false)} 
-                className="text-xs max-sm:hidden text-slate-400 dark:text-slate-500 hover:text-slate-700 dark:hover:text-slate-300 transition-colors font-medium px-2 py-1"
+                className="text-xs max-tablet-lg:hidden text-slate-400 dark:text-slate-500 hover:text-slate-700 dark:hover:text-slate-300 transition-colors font-medium px-2 py-1"
               >
                 Cancel
               </button>
               <button
                 onClick={handleSave}
                 disabled={!url.trim() || !(url.startsWith('http://') || url.startsWith('https://')) || createBookmarkMutation.isPending || createFolderMutation.isPending || isFoldersLoading}
-                className={`${styles.btnGradient} text-xs max-sm:text-[15px] font-bold px-6 max-sm:w-full py-2.5 max-sm:py-3.5 rounded-xl transition-all flex justify-center items-center gap-2 transform hover:-translate-y-0.5 active:translate-y-0 disabled:opacity-50 disabled:cursor-not-allowed shadow-lg max-sm:shadow-[0_4px_12px_rgba(124,58,237,0.2)]`}
+                className={`${styles.btnGradient} text-xs max-tablet-lg:text-[15px] font-bold px-6 max-tablet-lg:w-full py-2.5 max-tablet-lg:py-3.5 rounded-xl transition-all flex justify-center items-center gap-2 transform hover:-translate-y-0.5 active:translate-y-0 disabled:opacity-50 disabled:cursor-not-allowed shadow-lg max-tablet-lg:shadow-[0_4px_12px_rgba(124,58,237,0.2)]`}
               >
                 {(createBookmarkMutation.isPending || createFolderMutation.isPending) ? 'Saving...' : 'Save Link'}
               </button>

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -3,25 +3,61 @@
 import { usePathname } from "next/navigation";
 import { Sidebar } from "@/components/layout/Sidebar";
 import { Header } from "@/components/layout/Header";
+import { useUIStore } from "@/lib/store/uiStore";
+
+import { MobileBottomNavBar } from "@/components/layout/MobileBottomNavBar";
 
 export function AppLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
   const isLandingPage = pathname === "/";
   const isAuthPage = pathname === "/login";
+  
+  const mobileSidebarOpen = useUIStore((s) => s.mobileSidebarOpen);
+  const toggleMobileSidebar = useUIStore((s) => s.toggleMobileSidebar);
 
-  if (isLandingPage || isAuthPage) {
+  if (isLandingPage) {
+    return (
+      <>
+        {children}
+        <MobileBottomNavBar />
+      </>
+    );
+  }
+
+  if (isAuthPage) {
     return <>{children}</>;
   }
 
   return (
     <div className="relative flex min-h-screen w-full">
-      <Sidebar />
-      <main className="flex-1 flex flex-col h-full overflow-hidden bg-background-light dark:bg-background-dark w-full">
+      {/* Desktop Sidebar */}
+      <Sidebar className="hidden tablet-lg:flex" />
+      
+      {/* Mobile Sidebar (Drawer Overlay) */}
+      {mobileSidebarOpen && (
+        <div className="fixed inset-0 z-[100] flex tablet-lg:hidden">
+          {/* Backdrop */}
+          <div 
+            className="fixed inset-0 bg-slate-950/60 backdrop-blur-xs transition-opacity duration-300 animate-in fade-in"
+            onClick={() => toggleMobileSidebar(false)}
+          />
+          {/* Drawer Sidebar */}
+          <Sidebar 
+            className="relative z-[101] w-[210px] flex-shrink-0 h-full shadow-2xl animate-in slide-in-from-left duration-300" 
+            onClose={() => toggleMobileSidebar(false)}
+          />
+        </div>
+      )}
+
+      <main className="flex-grow flex flex-col h-full overflow-hidden bg-background-light dark:bg-background-dark w-full min-w-0">
         <Header />
-        <div className="flex-1 overflow-y-auto">
+        <div className="flex-grow overflow-hidden">
           {children}
         </div>
       </main>
+
+      {/* Global Mobile Bottom Navigation Bar */}
+      <MobileBottomNavBar />
     </div>
   );
 }

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -35,7 +35,7 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
       
       {/* Mobile Sidebar (Drawer Overlay) */}
       {mobileSidebarOpen && (
-        <div className="fixed inset-0 z-[100] flex tablet-lg:hidden">
+        <div className="fixed inset-0 z-drawer-backdrop flex tablet-lg:hidden">
           {/* Backdrop */}
           <div 
             className="fixed inset-0 bg-slate-950/60 backdrop-blur-xs transition-opacity duration-300 animate-in fade-in"
@@ -43,7 +43,7 @@ export function AppLayout({ children }: { children: React.ReactNode }) {
           />
           {/* Drawer Sidebar */}
           <Sidebar 
-            className="relative z-[101] w-[210px] flex-shrink-0 h-full shadow-2xl animate-in slide-in-from-left duration-300" 
+            className="relative z-drawer w-[210px] flex-shrink-0 h-full shadow-2xl animate-in slide-in-from-left duration-300" 
             onClose={() => toggleMobileSidebar(false)}
           />
         </div>

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -10,6 +10,7 @@ interface HeaderProps {
 
 export function Header({ title = 'My Links' }: HeaderProps) {
   const rightPanelOpen = useUIStore((s) => s.rightPanelOpen);
+  const toggleMobileSidebar = useUIStore((s) => s.toggleMobileSidebar);
   const { resolvedTheme, setTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
 
@@ -18,9 +19,26 @@ export function Header({ title = 'My Links' }: HeaderProps) {
   }, []);
 
   return (
-    <header className="h-8 flex bg-background-light dark:bg-background-dark flex-shrink-0 z-30 transition-colors duration-300">
+    <header className="h-10 tablet-lg:h-8 flex bg-background-light dark:bg-background-dark flex-shrink-0 z-30 transition-all duration-300">
       {/* Left: Content Area Header */}
-      <div className="flex-1 flex items-center px-4 dark:bg-white/[0.04]">
+      <div className="flex-1 flex items-center px-3 tablet-lg:px-4 dark:bg-white/[0.04]">
+        {/* Mobile Hamburger Button */}
+        <button
+          type="button"
+          onClick={() => toggleMobileSidebar()}
+          className="tablet-lg:hidden flex items-center justify-center p-1.5 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 rounded-md hover:bg-gray-100 dark:hover:bg-white/5 transition-colors mr-2"
+          title="메뉴 토글"
+        >
+          <span className="material-symbols-outlined !text-[18px]">menu</span>
+        </button>
+
+        {/* Mobile Logo */}
+        <div className="tablet-lg:hidden flex items-center space-x-1 mr-2 select-none">
+          <img src="/relink_logo.png" alt="Logo" className="w-4.5 h-4.5 object-contain" />
+          <span className="font-bold text-[11px] text-gray-800 dark:text-white tracking-tight">ReLink</span>
+        </div>
+        <span className="tablet-lg:hidden text-[9px] text-gray-400 opacity-40 mr-2">/</span>
+
         <div className="text-[10px] font-bold text-gray-400 dark:text-gray-500 flex items-center gap-1.5 tracking-tight select-none cursor-default">
           <span className="material-symbols-outlined !text-[14px] opacity-70">home</span>
           <span className="text-[9px] opacity-40">/</span>
@@ -29,9 +47,9 @@ export function Header({ title = 'My Links' }: HeaderProps) {
       </div>
 
       {/* Right: Actions / Right Panel Header Sync */}
-      <div className={`flex items-center px-4 transition-all duration-300 dark:bg-white/[0.04] ${
+      <div className={`flex items-center px-3 tablet-lg:px-4 transition-all duration-300 dark:bg-white/[0.04] ${
         rightPanelOpen 
-          ? 'xl:w-[700px] xl:bg-white xl:dark:bg-[#0a0a0b] xl:border-l xl:border-gray-200 xl:dark:border-white/[0.08]' 
+          ? 'tablet-lg:w-[700px] tablet-lg:bg-white tablet-lg:dark:bg-[#0a0a0b] tablet-lg:border-l tablet-lg:border-gray-200 tablet-lg:dark:border-white/[0.08]' 
           : ''
       }`}>
         <div className="ml-auto flex items-center space-x-1">
@@ -42,7 +60,7 @@ export function Header({ title = 'My Links' }: HeaderProps) {
           */}
           <button
             type="button"
-            className="p-1 text-gray-400 dark:text-gray-500 hover:bg-gray-100 dark:hover:bg-white/5 rounded-md transition-colors"
+            className="p-1.5 tablet-lg:p-1 text-gray-400 dark:text-gray-500 hover:bg-gray-100 dark:hover:bg-white/5 rounded-md transition-colors"
             onClick={() => setTheme(resolvedTheme === 'dark' ? 'light' : 'dark')}
           >
             <span className="material-symbols-outlined !text-[14px]">

--- a/frontend/src/components/layout/LandingHeader.tsx
+++ b/frontend/src/components/layout/LandingHeader.tsx
@@ -46,21 +46,29 @@ export function LandingHeader({ activeSection, isLoginPage = false }: LandingHea
   ];
 
   if (!mounted) return (
-    <header className="fixed w-full top-0 z-50 flex h-11 items-center justify-between whitespace-nowrap border-b border-white/10 bg-black/95 backdrop-blur-md px-6 lg:px-20 shadow-sm transition-all duration-300">
+    <header className={`fixed w-full top-0 z-50 flex h-9 md:h-11 items-center justify-between whitespace-nowrap px-5 sm:px-8 lg:px-20 transition-all duration-300 ${
+      isLoginPage 
+        ? "bg-[#F5F3FF]/85 dark:bg-[#020617]/85 backdrop-blur-md lg:bg-transparent text-slate-800 dark:text-white" 
+        : "border-b border-white/10 bg-black/95 backdrop-blur-md shadow-sm text-white"
+    }`}>
       <NextLink href="/" className="flex items-center space-x-2 group transition-opacity select-none">
         <Image src="/relink_logo.png" alt="ReLink" width={24} height={24} className="object-contain group-hover:scale-110 transition-transform" />
-        <span className="text-xl font-bold tracking-tight text-white uppercase sm:normal-case">ReLink</span>
+        <span className={`text-xl font-bold tracking-tight uppercase sm:normal-case ${isLoginPage ? 'text-slate-900 dark:text-white' : 'text-white'}`}>ReLink</span>
       </NextLink>
     </header>
   );
 
   return (
     <>
-      <header className="fixed w-full top-0 z-50 flex h-11 items-center justify-between whitespace-nowrap border-b border-white/10 bg-black/95 backdrop-blur-md px-6 lg:px-20 shadow-sm transition-all duration-300">
+      <header className={`fixed w-full top-0 z-50 flex h-9 md:h-11 items-center justify-between whitespace-nowrap px-5 sm:px-8 lg:px-20 transition-all duration-300 ${
+        isLoginPage 
+          ? "bg-[#F5F3FF]/85 dark:bg-[#020617]/85 backdrop-blur-md lg:bg-transparent text-slate-800 dark:text-white" 
+          : "border-b border-white/10 bg-black/95 backdrop-blur-md shadow-sm text-white"
+      }`}>
         {/* Logo */}
         <NextLink href="/" className="flex items-center space-x-2 group transition-opacity select-none" onClick={closeMenu}>
           <Image src="/relink_logo.png" alt="ReLink" width={24} height={24} className="object-contain group-hover:scale-110 transition-transform" />
-          <span className="text-xl font-bold tracking-tight text-white">ReLink</span>
+          <span className={`text-xl font-bold tracking-tight ${isLoginPage ? 'text-slate-900 dark:text-white' : 'text-white'}`}>ReLink</span>
         </NextLink>
 
         <div className="flex items-center gap-6">
@@ -69,7 +77,11 @@ export function LandingHeader({ activeSection, isLoginPage = false }: LandingHea
             {navLinks.map((link) => (
               <a 
                 key={link.name}
-                className="text-slate-300 hover:text-white text-[13px] font-medium transition-colors" 
+                className={`text-[13px] font-medium transition-colors ${
+                  isLoginPage 
+                    ? 'text-slate-600 dark:text-slate-300 hover:text-slate-900 dark:hover:text-white' 
+                    : 'text-slate-300 hover:text-white'
+                }`}
                 href={link.href}
                 {...(link.isExternal ? { target: "_blank", rel: "noopener noreferrer" } : {})}
               >
@@ -87,7 +99,11 @@ export function LandingHeader({ activeSection, isLoginPage = false }: LandingHea
             {/* Theme Toggle */}
             <button
               type="button"
-              className="flex items-center justify-center p-2 text-white hover:bg-white/10 rounded-full transition-colors"
+              className={`flex items-center justify-center p-1.5 md:p-2 rounded-full transition-colors ${
+                isLoginPage 
+                  ? 'text-slate-700 dark:text-slate-300 hover:bg-slate-200/50 dark:hover:bg-white/10' 
+                  : 'text-white hover:bg-white/10'
+              }`}
               onClick={() => setTheme(resolvedTheme === 'dark' ? 'light' : 'dark')}
               aria-label="테마 전환"
             >
@@ -98,7 +114,11 @@ export function LandingHeader({ activeSection, isLoginPage = false }: LandingHea
 
             {/* Mobile Menu Button */}
             <button 
-              className="md:hidden text-white flex items-center p-2 hover:bg-white/10 rounded-full transition-all active:scale-90"
+              className={`md:hidden flex items-center p-1.5 md:p-2 rounded-full transition-all active:scale-90 ${
+                isLoginPage 
+                  ? 'text-slate-800 dark:text-white hover:bg-slate-200/50 dark:hover:bg-white/10' 
+                  : 'text-white hover:bg-white/10'
+              }`}
               onClick={toggleMenu}
               aria-label="메뉴 열기"
             >

--- a/frontend/src/components/layout/LandingHeader.tsx
+++ b/frontend/src/components/layout/LandingHeader.tsx
@@ -46,7 +46,7 @@ export function LandingHeader({ activeSection, isLoginPage = false }: LandingHea
   ];
 
   if (!mounted) return (
-    <header className={`fixed w-full top-0 z-50 flex h-9 md:h-11 items-center justify-between whitespace-nowrap px-5 sm:px-8 lg:px-20 transition-all duration-300 ${
+    <header className={`fixed w-full top-0 z-sticky flex h-9 md:h-11 items-center justify-between whitespace-nowrap px-5 sm:px-8 lg:px-20 transition-all duration-300 ${
       isLoginPage 
         ? "bg-[#F5F3FF]/85 dark:bg-[#020617]/85 backdrop-blur-md lg:bg-transparent text-slate-800 dark:text-white" 
         : "border-b border-white/10 bg-black/95 backdrop-blur-md shadow-sm text-white"
@@ -60,7 +60,7 @@ export function LandingHeader({ activeSection, isLoginPage = false }: LandingHea
 
   return (
     <>
-      <header className={`fixed w-full top-0 z-50 flex h-9 md:h-11 items-center justify-between whitespace-nowrap px-5 sm:px-8 lg:px-20 transition-all duration-300 ${
+      <header className={`fixed w-full top-0 z-sticky flex h-9 md:h-11 items-center justify-between whitespace-nowrap px-5 sm:px-8 lg:px-20 transition-all duration-300 ${
         isLoginPage 
           ? "bg-[#F5F3FF]/85 dark:bg-[#020617]/85 backdrop-blur-md lg:bg-transparent text-slate-800 dark:text-white" 
           : "border-b border-white/10 bg-black/95 backdrop-blur-md shadow-sm text-white"
@@ -140,7 +140,7 @@ export function LandingHeader({ activeSection, isLoginPage = false }: LandingHea
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
               onClick={closeMenu}
-              className="fixed inset-0 z-[60] bg-black/60 backdrop-blur-sm md:hidden"
+              className="fixed inset-0 z-drawer-backdrop bg-black/60 backdrop-blur-sm md:hidden"
             />
 
             {/* Menu Panel */}
@@ -149,7 +149,7 @@ export function LandingHeader({ activeSection, isLoginPage = false }: LandingHea
               animate={{ x: 0 }}
               exit={{ x: "100%" }}
               transition={{ type: "spring", damping: 25, stiffness: 200 }}
-              className="fixed right-0 top-0 bottom-0 z-[70] w-[250px] bg-[#0a0a0b] border-l border-white/10 shadow-2xl md:hidden flex flex-col"
+              className="fixed right-0 top-0 bottom-0 z-drawer w-[250px] bg-[#0a0a0b] border-l border-white/10 shadow-2xl md:hidden flex flex-col"
             >
               <div className="flex flex-col h-full p-5">
                 <div className="flex items-center justify-between mb-8">

--- a/frontend/src/components/layout/MobileBottomNavBar.tsx
+++ b/frontend/src/components/layout/MobileBottomNavBar.tsx
@@ -1,0 +1,195 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname, useRouter } from 'next/navigation';
+import { useUIStore } from '@/lib/store/uiStore';
+import { useAuthStore } from '@/lib/store/authStore';
+import { useEffect, useState } from 'react';
+
+export function MobileBottomNavBar() {
+  const pathname = usePathname();
+  const router = useRouter();
+  const { isAuthenticated } = useAuthStore();
+  const { toggleSaveLinkDialog, saveLinkDialogOpen } = useUIStore();
+  const [mounted, setMounted] = useState(false);
+  const [clipboardUrl, setClipboardUrl] = useState<string | null>(null);
+  const [isTooltipVisible, setIsTooltipVisible] = useState(false);
+  const [shouldRenderTooltip, setShouldRenderTooltip] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  useEffect(() => {
+    const checkClipboard = async () => {
+      if (saveLinkDialogOpen) {
+        setClipboardUrl(null);
+        return;
+      }
+      if (typeof navigator === 'undefined' || !navigator.clipboard) {
+        return;
+      }
+      try {
+        const text = await navigator.clipboard.readText();
+        if (text && (text.startsWith('http://') || text.startsWith('https://'))) {
+          setClipboardUrl(text);
+        }
+      } catch (err) {
+        console.warn('Clipboard read error:', err);
+      }
+    };
+
+    if (mounted) {
+      checkClipboard();
+      window.addEventListener('focus', checkClipboard);
+    }
+    return () => {
+      window.removeEventListener('focus', checkClipboard);
+    };
+  }, [saveLinkDialogOpen, mounted]);
+
+  useEffect(() => {
+    let fadeInTimer: NodeJS.Timeout;
+    let fadeOutTimer: NodeJS.Timeout;
+    let clearTimer: NodeJS.Timeout;
+
+    if (clipboardUrl) {
+      setShouldRenderTooltip(true);
+
+      fadeInTimer = setTimeout(() => {
+        setIsTooltipVisible(true);
+      }, 50);
+
+      fadeOutTimer = setTimeout(() => {
+        setIsTooltipVisible(false);
+      }, 15000);
+
+      clearTimer = setTimeout(() => {
+        setShouldRenderTooltip(false);
+        setClipboardUrl(null);
+      }, 16000);
+    } else {
+      setIsTooltipVisible(false);
+      setShouldRenderTooltip(false);
+    }
+
+    return () => {
+      clearTimeout(fadeInTimer);
+      clearTimeout(fadeOutTimer);
+      clearTimeout(clearTimer);
+    };
+  }, [clipboardUrl]);
+
+  if (!mounted) return null;
+
+  const isMyLinks = pathname === '/my-links';
+
+  const handleCreateFolder = () => {
+    if (!isAuthenticated) {
+      router.push('/login');
+      return;
+    }
+    useUIStore.getState().toggleCreateFolderDialog(true);
+  };
+
+  const handleSaveLink = () => {
+    if (!isAuthenticated) {
+      router.push('/login');
+      return;
+    }
+    toggleSaveLinkDialog(true, clipboardUrl || undefined);
+    if (clipboardUrl) setClipboardUrl(null);
+  };
+
+  return (
+    <div className="tablet-lg:hidden fixed bottom-2 left-1/2 -translate-x-1/2 z-40 w-[calc(100%-2.5rem)] max-w-xs bg-white/85 dark:bg-slate-900/80 backdrop-blur-xl border border-gray-200/50 dark:border-white/[0.08] shadow-[0_20px_50px_rgba(0,0,0,0.15)] dark:shadow-[0_20px_50px_rgba(0,0,0,0.3)] rounded-full p-1 flex items-center justify-between gap-1 animate-in slide-in-from-bottom duration-300">
+      {/* Left: Navigation (Toggles dynamically between My Links and Home) */}
+      {isMyLinks ? (
+        <Link
+          href="/"
+          className="flex-1 flex flex-col items-center justify-center py-1 px-1 rounded-full text-gray-700 dark:text-gray-200 hover:bg-gray-50/80 dark:hover:bg-slate-800/40 transition-colors select-none"
+        >
+          <span className="material-symbols-outlined !text-[19px] text-gray-500 dark:text-gray-400">home</span>
+          <span className="text-[9px] font-normal tracking-tight text-gray-400 dark:text-gray-500 mt-[1px]">Overview</span>
+        </Link>
+      ) : (
+        <Link
+          href="/my-links"
+          className="flex-1 flex flex-col items-center justify-center py-1 px-1 rounded-full text-gray-700 dark:text-gray-200 hover:bg-gray-50/80 dark:hover:bg-slate-800/40 transition-colors select-none"
+        >
+          <span className="material-symbols-outlined !text-[19px] text-gray-500 dark:text-gray-400">bookmark</span>
+          <span className="text-[9px] font-normal tracking-tight text-gray-400 dark:text-gray-500 mt-[1px]">My Links</span>
+        </Link>
+      )}
+
+      {/* Center: Save Link primary action */}
+      <div className="flex-1 relative flex flex-col items-center justify-center">
+        {shouldRenderTooltip && clipboardUrl && (
+          <button
+            type="button"
+            onClick={() => {
+              toggleSaveLinkDialog(true, clipboardUrl);
+              setClipboardUrl(null);
+            }}
+            className={`absolute -top-14 left-1/2 -translate-x-1/2 z-50 group outline-none transition-all duration-1000 ease-in-out ${
+              isTooltipVisible 
+                ? 'opacity-100 translate-y-0 scale-100' 
+                : 'opacity-0 translate-y-2 scale-95 pointer-events-none'
+            }`}
+          >
+            <div className="relative w-[164px] h-[38px] flex items-center justify-center active:scale-95 transition-transform duration-150">
+              {/* Background Unified SVG Speech Bubble */}
+              <svg 
+                className="absolute -top-[2px] -left-[2px] w-[168px] h-[49px] drop-shadow-[0_12px_36px_rgba(124,58,237,0.3)] dark:drop-shadow-[0_12px_36px_rgba(0,0,0,0.6)] pointer-events-none" 
+                viewBox="-2 -2 168 49" 
+                fill="none" 
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                {/* Solid Fill */}
+                <path 
+                  d="M 19 0 L 145 0 A 19 19 0 0 1 164 19 A 19 19 0 0 1 145 38 L 91 38 C 86.5 38 84 39.5 82 45 C 80 39.5 77.5 38 73 38 L 19 38 A 19 19 0 0 1 0 19 A 19 19 0 0 1 19 0 Z" 
+                  className="fill-white dark:fill-[#0a0a0b] group-hover:fill-violet-50 dark:group-hover:fill-[#1c142c] transition-colors duration-300"
+                />
+                {/* Consistent Outer Border */}
+                <path 
+                  d="M 19 0 L 145 0 A 19 19 0 0 1 164 19 A 19 19 0 0 1 145 38 L 91 38 C 86.5 38 84 39.5 82 45 C 80 39.5 77.5 38 73 38 L 19 38 A 19 19 0 0 1 0 19 A 19 19 0 0 1 19 0 Z" 
+                  className="stroke-violet-200 dark:stroke-[#252528] transition-colors duration-300" 
+                  strokeWidth="2"
+                  strokeLinejoin="round"
+                />
+              </svg>
+
+              {/* Speech Bubble Content */}
+              <div className="relative z-10 flex items-center gap-2 pl-3.5 pr-4.5">
+                <div className="relative bg-[linear-gradient(135deg,#7c3aed_0%,#a855f7_100%)] w-5 h-5 rounded-full flex items-center justify-center flex-none overflow-hidden">
+                  <span className="inline-flex h-full w-full items-center justify-center rotate-[-45deg]">
+                    <span className="material-symbols-outlined !text-[12px] !leading-none block text-white font-bold">link</span>
+                  </span>
+                </div>
+                <span className="text-xs font-extrabold text-slate-800 dark:text-gray-50 tracking-tight pr-0.5 animate-pulse">Paste copied link</span>
+              </div>
+            </div>
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={handleSaveLink}
+          className="w-full flex flex-col items-center justify-center py-1 px-1 text-white bg-[linear-gradient(135deg,#6d28d9_0%,#8b5cf6_50%,#a78bfa_100%)] rounded-full hover:opacity-95 shadow-md shadow-purple-500/10 active:scale-[0.98] transition-all select-none"
+        >
+          <span className="material-symbols-outlined !text-[19px]">add</span>
+          <span className="text-[9px] font-medium tracking-tight text-white/90 mt-[1px]">Save Link</span>
+        </button>
+      </div>
+
+      {/* Right: Create Folder action */}
+      <button
+        type="button"
+        onClick={handleCreateFolder}
+        className="flex-1 flex flex-col items-center justify-center py-1 px-1 rounded-full text-gray-700 dark:text-gray-200 hover:bg-gray-50/80 dark:hover:bg-slate-800/40 transition-colors select-none"
+      >
+        <span className="material-symbols-outlined !text-[19px] text-gray-500 dark:text-gray-400">create_new_folder</span>
+        <span className="text-[9px] font-normal tracking-tight text-gray-400 dark:text-gray-500 mt-[1px]">New Folder</span>
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/layout/MobileBottomNavBar.tsx
+++ b/frontend/src/components/layout/MobileBottomNavBar.tsx
@@ -10,7 +10,7 @@ export function MobileBottomNavBar() {
   const pathname = usePathname();
   const router = useRouter();
   const { isAuthenticated } = useAuthStore();
-  const { toggleSaveLinkDialog, saveLinkDialogOpen } = useUIStore();
+  const { toggleSaveLinkDialog, saveLinkDialogOpen, toggleCreateFolderDialog } = useUIStore();
   const [mounted, setMounted] = useState(false);
   const [clipboardUrl, setClipboardUrl] = useState<string | null>(null);
   const [isTooltipVisible, setIsTooltipVisible] = useState(false);
@@ -21,6 +21,8 @@ export function MobileBottomNavBar() {
   }, []);
 
   useEffect(() => {
+    let timer: NodeJS.Timeout;
+
     const checkClipboard = async () => {
       if (saveLinkDialogOpen) {
         setClipboardUrl(null);
@@ -39,12 +41,18 @@ export function MobileBottomNavBar() {
       }
     };
 
+    const handleFocus = () => {
+      clearTimeout(timer);
+      timer = setTimeout(checkClipboard, 250);
+    };
+
     if (mounted) {
       checkClipboard();
-      window.addEventListener('focus', checkClipboard);
+      window.addEventListener('focus', handleFocus);
     }
     return () => {
-      window.removeEventListener('focus', checkClipboard);
+      clearTimeout(timer);
+      window.removeEventListener('focus', handleFocus);
     };
   }, [saveLinkDialogOpen, mounted]);
 
@@ -89,7 +97,7 @@ export function MobileBottomNavBar() {
       router.push('/login');
       return;
     }
-    useUIStore.getState().toggleCreateFolderDialog(true);
+    toggleCreateFolderDialog(true);
   };
 
   const handleSaveLink = () => {
@@ -127,10 +135,7 @@ export function MobileBottomNavBar() {
         {shouldRenderTooltip && clipboardUrl && (
           <button
             type="button"
-            onClick={() => {
-              toggleSaveLinkDialog(true, clipboardUrl);
-              setClipboardUrl(null);
-            }}
+            onClick={handleSaveLink}
             className={`absolute -top-14 left-1/2 -translate-x-1/2 z-50 group outline-none transition-all duration-1000 ease-in-out ${
               isTooltipVisible 
                 ? 'opacity-100 translate-y-0 scale-100' 

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -11,7 +11,12 @@ import { useRouter } from 'next/navigation';
 
 // const PINNED_DOT_COLORS = ['bg-blue-500', 'bg-purple-500', 'bg-teal-500', 'bg-amber-500', 'bg-emerald-500'];
 
-export function Sidebar() {
+export interface SidebarProps {
+  onClose?: () => void;
+  className?: string;
+}
+
+export function Sidebar({ onClose, className }: SidebarProps) {
   const pathname = usePathname();
   const router = useRouter();
   const logout = useAuthStore((s) => s.logout);
@@ -30,12 +35,24 @@ export function Sidebar() {
   ];
 
   return (
-    <aside className="w-[180px] bg-slate-950 text-white flex flex-col flex-shrink-0 h-full border-r border-white/5 z-40">
+    <aside className={cn("w-[180px] bg-slate-950 text-white flex flex-col flex-shrink-0 h-full border-r border-white/5 z-40", className)}>
       
       {/* Logo Area */}
-      <div className="p-4 flex items-center space-x-2 select-none cursor-default">
-        <img src="/relink_logo.png" alt="ReLink Logo" className="w-7 h-7 object-contain" />
-        <h1 className="text-xl font-bold tracking-tight">ReLink</h1>
+      <div className="p-4 flex items-center justify-between select-none cursor-default">
+        <div className="flex items-center space-x-2">
+          <img src="/relink_logo.png" alt="ReLink Logo" className="w-7 h-7 object-contain" />
+          <h1 className="text-xl font-bold tracking-tight">ReLink</h1>
+        </div>
+        {onClose && (
+          <button 
+            type="button" 
+            onClick={onClose}
+            className="tablet-lg:hidden p-1 text-gray-400 hover:text-white rounded-md hover:bg-white/10 transition-colors"
+            title="메뉴 닫기"
+          >
+            <span className="material-symbols-outlined text-[18px]!">menu_open</span>
+          </button>
+        )}
       </div>
 
       {/* User Profile Outline */}
@@ -55,6 +72,7 @@ export function Sidebar() {
               try {
                 await logout();
               } finally {
+                onClose?.();
                 router.push('/login');
               }
             }}
@@ -76,6 +94,7 @@ export function Sidebar() {
                 href={item.href}
                 target="_blank"
                 rel="noopener noreferrer"
+                onClick={onClose}
                 className="flex items-center space-x-2 px-3 py-2 rounded-lg text-xs transition-colors select-none text-gray-400 hover:text-white hover:bg-white/5"
               >
                 <div className="w-5 h-5 flex items-center justify-center shrink-0">
@@ -93,6 +112,7 @@ export function Sidebar() {
             <Link
               key={item.href}
               href={item.href}
+              onClick={onClose}
               className={cn(
                 'flex items-center space-x-2 px-3 py-2 rounded-lg text-xs transition-colors select-none',
                 isActive 

--- a/frontend/src/components/my-links/FolderCard.tsx
+++ b/frontend/src/components/my-links/FolderCard.tsx
@@ -155,7 +155,7 @@ export function FolderCard({ folder, color }: FolderCardProps) {
         </div>
 
         <div>
-          <h4 className="font-semibold text-[10px] xl:text-[11px] text-gray-800 dark:text-white truncate mt-1.5">
+          <h4 className="font-semibold text-[10.5px] xl:text-[11.5px] text-gray-800 dark:text-white truncate mt-1.5">
             {folder.folderName}
           </h4>
         </div>
@@ -176,6 +176,7 @@ export function FolderCard({ folder, color }: FolderCardProps) {
             <span className="material-symbols-outlined !text-[16px] !leading-none">edit</span>
             <span className="font-medium">Rename</span>
           </button>
+          {/*
           <button
             onClick={(e) => handleMenuItemClick('move', e)}
             disabled={isSystemFolder}
@@ -184,6 +185,7 @@ export function FolderCard({ folder, color }: FolderCardProps) {
             <span className="material-symbols-outlined !text-[16px] !leading-none">drive_file_move</span>
             <span className="font-medium">Move</span>
           </button>
+          */}
           <div className="h-px bg-gray-50 dark:bg-white/8 my-0.5" />
           <button
             onClick={(e) => handleMenuItemClick('delete', e)}

--- a/frontend/src/components/my-links/FolderCard.tsx
+++ b/frontend/src/components/my-links/FolderCard.tsx
@@ -166,7 +166,7 @@ export function FolderCard({ folder, color }: FolderCardProps) {
       {showMenu && menuPosition && createPortal(
         <div
           ref={menuRef}
-          className="fixed w-28 bg-white dark:bg-slate-950 border border-gray-100 dark:border-white/8 shadow-xl rounded-lg py-1 z-[120] animate-in fade-in slide-in-from-top-1 duration-150"
+          className="fixed w-28 bg-white dark:bg-slate-950 border border-gray-100 dark:border-white/8 shadow-xl rounded-lg py-1 z-popover animate-in fade-in slide-in-from-top-1 duration-150"
           style={{ top: menuPosition.top, left: menuPosition.left }}
         >
           <button

--- a/frontend/src/components/my-links/RightPanel.tsx
+++ b/frontend/src/components/my-links/RightPanel.tsx
@@ -10,7 +10,7 @@ import { SortDropdown, SortOption } from '@/components/ui/SortDropdown';
 import type { BookmarkResponse } from '@/lib/types/bookmark';
 import { FOLDER_TYPE } from '@/lib/types/folder';
 import { compareFolders } from '@/lib/utils/folderUtils';
-import { buildGoogleFaviconUrl, getUrlHostname, buildDirectFaviconUrl } from '@/lib/utils/favicon';
+import { buildGoogleFaviconUrl, getUrlHostname, buildDirectFaviconUrl, isGoogleFaviconUrl } from '@/lib/utils/favicon';
 
 /**
  * 날짜 문자열을 받아 현재 시간 기준 상대적인 시간(예: Just now, 5m ago)으로 변환합니다.
@@ -69,11 +69,15 @@ function LinkItem({
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);               // 더보기 메뉴 오픈 여부 
   const [isFolderDropdownOpen, setIsFolderDropdownOpen] = useState(false);   // 폴더 이동 드롭다운 여부
   const [faviconFallbackStep, setFaviconFallbackStep] = useState<'google' | 'direct' | 'failed'>('google');
+  const [faviconVisible, setFaviconVisible] = useState(false);
+  const storedFaviconUrl = data.link?.faviconUrl ?? null;
+  const faviconSourceUrl = data.link?.originalUrl ?? data.link?.canonicalUrl ?? data.link?.domain;
 
   // 북마크 데이터가 바뀌면 파비콘 재시도 플래그를 리셋합니다.
   useEffect(() => {
     setFaviconFallbackStep('google');
-  }, [data.bookmarkId]);
+    setFaviconVisible(false);
+  }, [data.bookmarkId, storedFaviconUrl, faviconSourceUrl]);
   
   const noteInputRef = useRef<HTMLInputElement>(null);     // 메모 입력창 참조
   const titleInputRef = useRef<HTMLInputElement>(null);    // 제목 입력창 참조
@@ -108,8 +112,6 @@ function LinkItem({
     }
     return null;
   })();
-  const faviconSourceUrl = data.link?.originalUrl ?? data.link?.canonicalUrl ?? data.link?.domain;
-
   const fallbackDomain =
     getUrlHostname(data.link?.originalUrl) ??
     getUrlHostname(data.link?.canonicalUrl) ??
@@ -306,14 +308,34 @@ function LinkItem({
 
       {/* Favicon & Domain Icon | 파비콘 및 도메인 아이콘 */}
       <div className={`relative z-10 h-8 w-8 rounded-lg bg-gray-100 text-gray-400 dark:text-gray-500 flex items-center justify-center flex-shrink-0 text-xs font-bold shrink-0 overflow-hidden border border-gray-100 transition-all duration-300 group-hover:-translate-y-0.5 group-hover:border-violet-200/90 group-hover:bg-[linear-gradient(135deg,rgba(255,255,255,0.98)_0%,rgba(243,232,255,0.96)_100%)] group-hover:text-violet-600 group-hover:shadow-[0_12px_20px_-12px_rgba(124,58,237,0.28)] ${iconDarkClass}`}>
-        {data.link?.faviconUrl ? (
-          <img 
-            src={data.link.faviconUrl} 
-            alt="" 
-            className="w-5 h-5 object-contain" 
-            onLoad={(e) => {
-              const img = e.currentTarget;
-              if (img.naturalWidth === 16 && img.naturalHeight === 16) {
+        {/* 로딩 지연 시 답답함을 주지 않기 위해 알파벳을 우선 띄우고, 성공 시에만 opacity-0으로 숨김 */}
+        <span className={`uppercase absolute transition-opacity duration-200 ${faviconVisible ? 'opacity-0' : 'opacity-100'}`}>{fallbackInitial}</span>
+        
+        {faviconFallbackStep !== 'failed' && (
+          storedFaviconUrl ? (
+            <img 
+              src={storedFaviconUrl} 
+              alt="" 
+              className={`w-5 h-5 object-contain transition-opacity duration-200 relative z-10 ${faviconVisible ? 'opacity-100' : 'opacity-0'}`} 
+              onLoad={(e) => {
+                const img = e.currentTarget;
+                const fallbackStep = img.dataset.fallbackStep;
+                const isGoogleRequest = fallbackStep === 'google' || (!fallbackStep && isGoogleFaviconUrl(storedFaviconUrl));
+                if (isGoogleRequest && img.naturalWidth === 16 && img.naturalHeight === 16) {
+                  setFaviconVisible(false);
+                  if (!fallbackStep || fallbackStep === 'google') {
+                    img.dataset.fallbackStep = 'direct';
+                    img.src = buildDirectFaviconUrl(faviconSourceUrl) || '';
+                  } else {
+                    setFaviconFallbackStep('failed');
+                  }
+                } else {
+                  setFaviconVisible(true);
+                }
+              }}
+              onError={(e) => {
+                setFaviconVisible(false);
+                const img = e.currentTarget;
                 if (!img.dataset.fallbackStep) {
                   img.dataset.fallbackStep = 'google';
                   img.src = buildGoogleFaviconUrl(faviconSourceUrl) || '';
@@ -321,61 +343,34 @@ function LinkItem({
                   img.dataset.fallbackStep = 'direct';
                   img.src = buildDirectFaviconUrl(faviconSourceUrl) || '';
                 } else {
-                  img.style.display = 'none';
-                  if (img.parentElement) {
-                    img.parentElement.textContent = fallbackInitial;
-                  }
+                  setFaviconFallbackStep('failed');
                 }
-              }
-            }}
-            onError={(e) => {
-              const img = e.currentTarget;
-              if (!img.dataset.fallbackStep) {
-                img.dataset.fallbackStep = 'google';
-                img.src = buildGoogleFaviconUrl(faviconSourceUrl) || '';
-              } else if (img.dataset.fallbackStep === 'google') {
-                img.dataset.fallbackStep = 'direct';
-                img.src = buildDirectFaviconUrl(faviconSourceUrl) || '';
-              } else {
-                img.style.display = 'none';
-                if (img.parentElement) {
-                  img.parentElement.textContent = fallbackInitial;
+              }}
+            />
+          ) : fallbackFaviconUrl ? (
+            <img 
+              src={fallbackFaviconUrl} 
+              alt="" 
+              className={`w-5 h-5 object-contain transition-opacity duration-200 relative z-10 ${faviconVisible ? 'opacity-100' : 'opacity-0'}`}
+              onLoad={(e) => {
+                const img = e.currentTarget;
+                if (faviconFallbackStep === 'google' && img.naturalWidth === 16 && img.naturalHeight === 16) {
+                  setFaviconVisible(false);
+                  setFaviconFallbackStep('direct');
+                } else {
+                  setFaviconVisible(true);
                 }
-              }
-            }}
-          />
-        ) : fallbackFaviconUrl ? (
-          <img 
-            src={fallbackFaviconUrl} 
-            alt="" 
-            className="w-5 h-5 object-contain"
-            onLoad={(e) => {
-              const img = e.currentTarget;
-              if (img.naturalWidth === 16 && img.naturalHeight === 16) {
+              }}
+              onError={() => {
+                setFaviconVisible(false);
                 if (faviconFallbackStep === 'google') {
                   setFaviconFallbackStep('direct');
                 } else {
-                  img.style.display = 'none';
-                  if (img.parentElement) {
-                    img.parentElement.textContent = fallbackInitial;
-                  }
+                  setFaviconFallbackStep('failed');
                 }
-              }
-            }}
-            onError={(e) => {
-              const img = e.currentTarget;
-              if (faviconFallbackStep === 'google') {
-                setFaviconFallbackStep('direct');
-              } else {
-                img.style.display = 'none';
-                if (img.parentElement) {
-                  img.parentElement.textContent = fallbackInitial;
-                }
-              }
-            }}
-          />
-        ) : (
-          <span className="uppercase">{fallbackInitial}</span>
+              }}
+            />
+          ) : null
         )}
       </div>
       <div className="relative z-10 ml-3 flex-1 flex flex-col min-w-0">
@@ -737,7 +732,7 @@ export function RightPanel() {
 
   // Client-side filtering logic (Tags only; date/unread/folder filters are handled by the API)
   const allLinks = bookmarks ?? [];
-  let filteredLinks = selectedTags.length > 0
+  const filteredLinks = selectedTags.length > 0
     ? allLinks.filter(link => link.tags?.some(tag => selectedTags.includes(tag)))
     : allLinks;
   const emptyLinksMessage = (() => {
@@ -1117,7 +1112,13 @@ export function RightPanel() {
               </div>
             )}
           </div>
-          <button className="flex items-center justify-center p-1.5 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-800 rounded-lg transition-colors ml-2 shrink-0">
+          <button 
+            onClick={() => {
+              setSortOption(prev => prev === 'newest' ? 'oldest' : 'newest');
+            }}
+            className="flex items-center justify-center p-1.5 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-800 rounded-lg transition-colors ml-2 shrink-0"
+            title="Toggle sort order"
+          >
             <span className="material-symbols-outlined !text-[12px] !leading-none">swap_vert</span>
           </button>
         </div>

--- a/frontend/src/components/my-links/RightPanel.tsx
+++ b/frontend/src/components/my-links/RightPanel.tsx
@@ -507,7 +507,7 @@ function LinkItem({
       {!isNoteEditing && noteContent && !isDropdownOpen && (
         <div className="absolute right-12 top-1/2 -translate-y-1/2 mr-2 w-max max-w-[280px] z-[60] opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 bg-white/95 dark:bg-gray-800/90 backdrop-blur-md text-gray-700 dark:text-gray-200 text-[11px] font-medium p-3 rounded-xl shadow-xl border border-gray-100 dark:border-gray-700/50 whitespace-normal break-words leading-relaxed pointer-events-none translate-x-1 group-hover:translate-x-0 text-left">
           <div className="absolute top-1/2 -translate-y-1/2 -left-1.5 w-3 h-3 bg-white/95 dark:bg-gray-800/90 transform rotate-45 border-b border-l border-gray-100 dark:border-gray-700/50"></div>
-          <div className="relative z-10 break-all xl:break-words">{noteContent}</div>
+          <div className="relative z-10 break-all tablet-lg:break-words">{noteContent}</div>
         </div>
       )}
 
@@ -598,6 +598,12 @@ function LinkItem({
 export function RightPanel() {
   // --- Central State (Zustand) | 중앙 상태 관리 ---
   const { rightPanelOpen } = useUIStore(); // 패널 오픈 여부
+  const [mounted, setMounted] = useState(false);
+  
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
   const selectedFolderId = useFolderStore((s) => s.selectedFolderId); // 현재 선택된 폴더 ID
   const memberId = useAuthStore((s) => s.member?.memberId);
   const linkSearchQuery = useLinkStore((s) => s.filters.searchQuery); // 현재 검색어 상태 구독
@@ -925,26 +931,45 @@ export function RightPanel() {
   if (!rightPanelOpen) return null;
 
   return (
-    <aside className="w-[700px] shrink-0 bg-white dark:bg-[#0a0a0b] border-l border-gray-200 dark:border-white/[0.08] hidden xl:flex flex-col h-full shadow-2xl z-10 transition-all duration-300 relative">
+    <aside className={`fixed inset-y-0 right-0 z-50 bg-white dark:bg-[#0a0a0b] flex flex-col w-full h-full shadow-2xl transition-colors duration-300 tablet-lg:relative tablet-lg:inset-auto tablet-lg:w-[700px] tablet-lg:shrink-0 tablet-lg:border-l tablet-lg:border-gray-200 tablet-lg:dark:border-white/[0.08] tablet-lg:shadow-none tablet-lg:z-10 tablet-lg:flex ${
+      mounted
+        ? "flex animate-in slide-in-from-right duration-300 tablet-lg:animate-none"
+        : "hidden tablet-lg:flex"
+    }`}>
       
       {/* Top Header & Tags | 상단 헤더 및 태그 필터 영역 */}
       <div className="px-5 py-3 border-b border-gray-100 dark:border-white/[0.05] flex flex-col gap-2 bg-white dark:bg-[#0a0a0b] sticky top-0 z-[15]">
         
         {/* Row 1: Title & Actions */}
-        <div className="flex justify-between items-start">
-          {/* Left: Title and Count | 좌측: 폴더명 및 링크 개수 */}
-          <div className="flex flex-col">
-            <div className="flex items-center gap-2">
-              <div className="p-1.5 bg-slate-50 dark:bg-slate-900/20 text-slate-400 rounded-md flex items-center justify-center w-8 h-8">
-                <span className="material-symbols-outlined text-[16px] block">folder_open</span>
+        <div className="flex flex-col tablet-lg:flex-row tablet-lg:justify-between tablet-lg:items-start gap-3 tablet-lg:gap-0">
+          {/* Left: Title, Count, and Mobile Close button */}
+          <div className="flex justify-between items-start w-full tablet-lg:w-auto">
+            <div className="flex flex-col">
+              <div className="flex items-center gap-2">
+                <div className="p-1.5 bg-slate-50 dark:bg-slate-900/20 text-slate-400 rounded-md flex items-center justify-center w-8 h-8">
+                  <span className="material-symbols-outlined text-[16px] block">folder_open</span>
+                </div>
+                <h2 className="text-sm font-bold text-gray-900 dark:text-white">{displayTitle}</h2>
               </div>
-              <h2 className="text-sm font-bold text-gray-900 dark:text-white">{displayTitle}</h2>
+              <p className="text-[10px] text-gray-500">{totalCount} Links</p>
             </div>
-            <p className="text-[10px] text-gray-500">{totalCount} Links</p>
+
+            {/* Close Button (Mobile/Tablet Only) */}
+            <button
+              type="button"
+              onClick={() => {
+                useUIStore.getState().toggleRightPanel(false);
+                useFolderStore.getState().setSelectedFolderId(null);
+              }}
+              className="tablet-lg:hidden flex items-center justify-center p-1.5 bg-slate-100 hover:bg-slate-200 dark:bg-slate-800 dark:hover:bg-slate-700 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 rounded-lg transition-colors w-8 h-8 shrink-0"
+              title="Close panel"
+            >
+              <span className="material-symbols-outlined !text-[18px]">close</span>
+            </button>
           </div>
 
           {/* Right: Action Buttons & Search | 우측 액션 버튼 및 검색창 */}
-          <div className="flex items-center gap-1.5 mt-0.5">
+          <div className="flex flex-wrap items-center gap-1.5 mt-0.5 w-full tablet-lg:w-auto">
             {/* Tags Dropdown Filter | 태그 필터 드롭다운 */}
             <div className="relative" ref={tagDropdownRef}>
               <button 

--- a/frontend/src/components/my-links/RightPanel.tsx
+++ b/frontend/src/components/my-links/RightPanel.tsx
@@ -505,7 +505,7 @@ function LinkItem({
 
       {/* Tooltip for full note content (위치 우측 복구 & 꼬리만 왼쪽 유지) */}
       {!isNoteEditing && noteContent && !isDropdownOpen && (
-        <div className="absolute right-12 top-1/2 -translate-y-1/2 mr-2 w-max max-w-[280px] z-[60] opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 bg-white/95 dark:bg-gray-800/90 backdrop-blur-md text-gray-700 dark:text-gray-200 text-[11px] font-medium p-3 rounded-xl shadow-xl border border-gray-100 dark:border-gray-700/50 whitespace-normal break-words leading-relaxed pointer-events-none translate-x-1 group-hover:translate-x-0 text-left">
+        <div className="absolute right-12 top-1/2 -translate-y-1/2 mr-2 w-max max-w-[280px] z-popover opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-300 bg-white/95 dark:bg-gray-800/90 backdrop-blur-md text-gray-700 dark:text-gray-200 text-[11px] font-medium p-3 rounded-xl shadow-xl border border-gray-100 dark:border-gray-700/50 whitespace-normal break-words leading-relaxed pointer-events-none translate-x-1 group-hover:translate-x-0 text-left">
           <div className="absolute top-1/2 -translate-y-1/2 -left-1.5 w-3 h-3 bg-white/95 dark:bg-gray-800/90 transform rotate-45 border-b border-l border-gray-100 dark:border-gray-700/50"></div>
           <div className="relative z-10 break-all tablet-lg:break-words">{noteContent}</div>
         </div>
@@ -931,14 +931,14 @@ export function RightPanel() {
   if (!rightPanelOpen) return null;
 
   return (
-    <aside className={`fixed inset-y-0 right-0 z-50 bg-white dark:bg-[#0a0a0b] flex flex-col w-full h-full shadow-2xl transition-colors duration-300 tablet-lg:relative tablet-lg:inset-auto tablet-lg:w-[700px] tablet-lg:shrink-0 tablet-lg:border-l tablet-lg:border-gray-200 tablet-lg:dark:border-white/[0.08] tablet-lg:shadow-none tablet-lg:z-10 tablet-lg:flex ${
+    <aside className={`fixed inset-y-0 right-0 z-drawer bg-white dark:bg-[#0a0a0b] flex flex-col w-full h-full shadow-2xl transition-colors duration-300 tablet-lg:relative tablet-lg:inset-auto tablet-lg:w-[700px] tablet-lg:shrink-0 tablet-lg:border-l tablet-lg:border-gray-200 tablet-lg:dark:border-white/[0.08] tablet-lg:shadow-none tablet-lg:z-10 tablet-lg:flex ${
       mounted
         ? "flex animate-in slide-in-from-right duration-300 tablet-lg:animate-none"
         : "hidden tablet-lg:flex"
     }`}>
       
       {/* Top Header & Tags | 상단 헤더 및 태그 필터 영역 */}
-      <div className="px-5 py-3 border-b border-gray-100 dark:border-white/[0.05] flex flex-col gap-2 bg-white dark:bg-[#0a0a0b] sticky top-0 z-[15]">
+      <div className="px-5 py-3 border-b border-gray-100 dark:border-white/[0.05] flex flex-col gap-2 bg-white dark:bg-[#0a0a0b] sticky top-0 z-sticky">
         
         {/* Row 1: Title & Actions */}
         <div className="flex flex-col tablet-lg:flex-row tablet-lg:justify-between tablet-lg:items-start gap-3 tablet-lg:gap-0">

--- a/frontend/src/components/ui/SortDropdown.tsx
+++ b/frontend/src/components/ui/SortDropdown.tsx
@@ -84,7 +84,9 @@ export function SortDropdown({
               : "opacity-50 cursor-not-allowed grayscale-[0.5]"
           )}
         >
-          <span className="material-symbols-outlined !text-[12px] text-gray-400 dark:text-gray-500 group-hover:text-purple-500 dark:group-hover:text-purple-400 transition-colors">filter_list</span>
+          <span className="material-symbols-outlined !text-[12px] text-gray-400 dark:text-gray-500 group-hover:text-purple-500 dark:group-hover:text-purple-400 transition-colors">
+            {selectedOption?.icon || 'filter_list'}
+          </span>
           <span>{selectedOption?.label || (hasOptions ? '' : '선택 불가')}</span>
           <span className={cn(
             "material-symbols-outlined !text-[12px] text-gray-400 dark:text-gray-500 transition-all duration-200 group-hover:text-purple-500 dark:group-hover:text-purple-400",

--- a/frontend/src/components/ui/StarField.tsx
+++ b/frontend/src/components/ui/StarField.tsx
@@ -1,0 +1,82 @@
+import React, { useEffect, useState } from "react";
+
+interface Star {
+  id: number;
+  left: string;
+  top: string;
+  width: string;
+  height: string;
+  backgroundColor: string;
+  animation: string;
+  boxShadow: string;
+}
+
+interface StarFieldProps {
+  count?: number;
+  opacity?: number;
+  keyPrefix?: string;
+}
+
+export function StarField({ count = 45, opacity = 0.4, keyPrefix = "star" }: StarFieldProps) {
+  const [stars, setStars] = useState<Star[]>([]);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+    
+    // Generate star attributes only once on mount to avoid hydration mismatch and render jitter
+    const generatedStars = Array.from({ length: count }).map((_, i) => {
+      const isIndigo = i % 4 === 0;
+      const isCyan = i % 5 === 0;
+      const backgroundColor = isIndigo ? "#7c3aed" : isCyan ? "#0ea5e9" : "#ffffff";
+      
+      const hasTwinkle = i % 3 === 0;
+      const animation = hasTwinkle
+        ? `twinkle ${Math.random() * 3 + 2}s ease-in-out infinite ${Math.random() * 5}s`
+        : "none";
+        
+      const hasIndigoShadow = i % 8 === 0;
+      const hasCyanShadow = i % 12 === 0;
+      const boxShadow = hasIndigoShadow
+        ? "0 0 10px 1px rgba(124,58,237,0.3)"
+        : hasCyanShadow
+        ? "0 0 12px 2px rgba(14,165,233,0.3)"
+        : "none";
+
+      return {
+        id: i,
+        left: `${Math.random() * 100}%`,
+        top: `${Math.random() * 100}%`,
+        width: `${Math.random() * 2.5 + 0.5}px`,
+        height: `${Math.random() * 2.5 + 0.5}px`,
+        backgroundColor,
+        animation,
+        boxShadow,
+      };
+    });
+    setStars(generatedStars);
+  }, [count]);
+
+  if (!mounted) return null;
+
+  return (
+    <div className="absolute inset-0 hidden dark:block pointer-events-none">
+      {stars.map((star) => (
+        <div
+          key={`${keyPrefix}-${star.id}`}
+          className="absolute rounded-full transition-all duration-1000"
+          style={{
+            left: star.left,
+            top: star.top,
+            width: star.width,
+            height: star.height,
+            backgroundColor: star.backgroundColor,
+            opacity,
+            animation: star.animation,
+            boxShadow: star.boxShadow,
+          }}
+        />
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/lib/store/uiStore.ts
+++ b/frontend/src/lib/store/uiStore.ts
@@ -3,28 +3,42 @@ import { create } from 'zustand';
 interface UIStore {
   // Dialog States
   saveLinkDialogOpen: boolean;
+  saveLinkDefaultUrl?: string;
   createFolderDialogOpen: boolean;
 
   // Panel States
   rightPanelOpen: boolean;
+  mobileSidebarOpen: boolean;
 
   // Actions
-  toggleSaveLinkDialog: (open?: boolean) => void;
+  toggleSaveLinkDialog: (open?: boolean, defaultUrl?: string) => void;
   toggleCreateFolderDialog: (open?: boolean) => void;
   toggleRightPanel: (open?: boolean) => void;
+  toggleMobileSidebar: (open?: boolean) => void;
 }
 
 export const useUIStore = create<UIStore>((set) => ({
   saveLinkDialogOpen: false,
+  saveLinkDefaultUrl: undefined,
   createFolderDialogOpen: false,
-  rightPanelOpen: true,
+  rightPanelOpen: false,
+  mobileSidebarOpen: false,
 
-  toggleSaveLinkDialog: (open) =>
-    set((state) => ({ saveLinkDialogOpen: open ?? !state.saveLinkDialogOpen })),
+  toggleSaveLinkDialog: (open, defaultUrl) =>
+    set((state) => {
+      const nextOpen = open ?? !state.saveLinkDialogOpen;
+      return {
+        saveLinkDialogOpen: nextOpen,
+        saveLinkDefaultUrl: nextOpen ? defaultUrl : undefined,
+      };
+    }),
 
   toggleCreateFolderDialog: (open) =>
     set((state) => ({ createFolderDialogOpen: open ?? !state.createFolderDialogOpen })),
 
   toggleRightPanel: (open) =>
     set((state) => ({ rightPanelOpen: open ?? !state.rightPanelOpen })),
+
+  toggleMobileSidebar: (open) =>
+    set((state) => ({ mobileSidebarOpen: open ?? !state.mobileSidebarOpen })),
 }));

--- a/frontend/src/lib/types/folder.ts
+++ b/frontend/src/lib/types/folder.ts
@@ -16,6 +16,7 @@ export interface FolderResponse {
   folderName: string;
   description: string | null;
   folderType: FolderType;
+  bookmarkCount: number;
 }
 
 // POST /api/folders 요청 바디

--- a/frontend/src/lib/utils/favicon.ts
+++ b/frontend/src/lib/utils/favicon.ts
@@ -1,5 +1,7 @@
 const HTTP_URL_PATTERN = /^[a-zA-Z][a-zA-Z\d+\-.]*:\/\//;
 const WRAPPING_QUOTES_PATTERN = /^[\s"'`]+|[\s"'`]+$/g;
+const GOOGLE_FAVICON_HOSTNAME = 'www.google.com';
+const GOOGLE_FAVICON_PATHNAME = '/s2/favicons';
 
 // 사용자 입력값을 파싱 가능한 http/https URL로 정규화합니다.
 function parseHttpUrl(urlStr?: string | null): URL | null {
@@ -34,7 +36,18 @@ export function buildGoogleFaviconUrl(urlStr?: string | null, size = 64): string
   // ?token=... 또는 #hash 등 민감 정보가 포함된 쿼리와 해시를 제거하여 보안을 강화.
   const safeUrl = parsed.origin;
 
-  return `https://www.google.com/s2/favicons?sz=${size}&domain_url=${encodeURIComponent(safeUrl)}`;
+  return `https://${GOOGLE_FAVICON_HOSTNAME}${GOOGLE_FAVICON_PATHNAME}?sz=${size}&domain_url=${encodeURIComponent(safeUrl)}`;
+}
+
+export function isGoogleFaviconUrl(urlStr?: string | null): boolean {
+  if (!urlStr) return false;
+
+  try {
+    const parsed = new URL(urlStr);
+    return parsed.hostname === GOOGLE_FAVICON_HOSTNAME && parsed.pathname === GOOGLE_FAVICON_PATHNAME;
+  } catch {
+    return false;
+  }
 }
 
 // Google S2가 실패하거나 기본 아이콘을 반환하면 원 도메인의 /favicon.ico를 직접 시도합니다.

--- a/frontend/src/lib/utils/folderUtils.ts
+++ b/frontend/src/lib/utils/folderUtils.ts
@@ -5,11 +5,13 @@ import { FOLDER_TYPE, type FolderResponse } from '@/lib/types/folder';
  * 그 외의 폴더들은 선택된 정렬 방식에 따라 정렬하는 비교 함수입니다.
  */
 export const compareFolders = (a: FolderResponse, b: FolderResponse, sortType?: string) => {
-  if (a.folderType === FOLDER_TYPE.UNORGANIZED && b.folderType !== FOLDER_TYPE.UNORGANIZED) return -1;
-  if (b.folderType === FOLDER_TYPE.UNORGANIZED && a.folderType !== FOLDER_TYPE.UNORGANIZED) return 1;
-  
   if (sortType === 'recently') return b.memberFolderId - a.memberFolderId;
   if (sortType === 'a-z') return a.folderName.localeCompare(b.folderName);
+  if (sortType === 'count') {
+    const countDiff = (b.bookmarkCount || 0) - (a.bookmarkCount || 0);
+    if (countDiff !== 0) return countDiff;
+    return b.memberFolderId - a.memberFolderId; // 개수가 같으면 최근 생성 순
+  }
   
   return 0;
 };

--- a/src/main/java/com/web/SearchWeb/folder/controller/dto/MemberFolderResponses.java
+++ b/src/main/java/com/web/SearchWeb/folder/controller/dto/MemberFolderResponses.java
@@ -13,6 +13,7 @@ public class MemberFolderResponses {
     private final String folderName;
     private final String description;
     private final String folderType;
+    private final Integer bookmarkCount;
 
     // Entity -> DTO 변환을 위한 정적 팩토리 메서드
     public static MemberFolderResponses from(MemberFolder folder) {
@@ -23,6 +24,7 @@ public class MemberFolderResponses {
             .folderName(folder.getFolderName())
             .description(folder.getDescription())
             .folderType(folder.getFolderType().name())
+            .bookmarkCount(folder.getBookmarkCount())
             .build();
     }
 }

--- a/src/main/java/com/web/SearchWeb/folder/domain/MemberFolder.java
+++ b/src/main/java/com/web/SearchWeb/folder/domain/MemberFolder.java
@@ -17,6 +17,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
+import org.hibernate.annotations.Formula;
+import org.hibernate.annotations.SQLRestriction;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -24,7 +26,7 @@ import lombok.experimental.SuperBuilder;
 @SuperBuilder
 @Entity
 @Table(name = "member_folder")
-@org.hibernate.annotations.SQLRestriction("deleted_at IS NULL")
+@SQLRestriction("deleted_at IS NULL")
 public class MemberFolder extends BaseEntity {
 
     @Id
@@ -43,6 +45,9 @@ public class MemberFolder extends BaseEntity {
     @Column(name = "folder_type", nullable = false, length = 20)
     @Builder.Default
     private FolderType folderType = FolderType.CUSTOM;
+
+    @Formula("(SELECT COUNT(*) FROM member_saved_link msl WHERE msl.member_folder_id = member_folder_id AND msl.deleted_at IS NULL)")
+    private Integer bookmarkCount;
 
     public boolean isUnorganized() {
         return FolderType.UNORGANIZED.equals(this.folderType);


### PR DESCRIPTION

## 💡 이슈
resolve {#50}

## 🤩 개요
- 폴더 목록의 북마크 수 기준 정렬을 구현하기 위해 백엔드 필드를 확장
- 프론트엔드 정렬 애니메이션 및 파비콘 UX(폴백, 로딩 애니메이션)를 개선

🧑💻 작업 사항

[Backend]
- MemberFolder / MemberFolderResponses: 폴더별 실시간 북마크 수(bookmarkCount) 산출 필드 추가 및 DTO 매핑.

[Frontend]
- folder.ts / folderUtils.ts: bookmarkCount 타입 연동 및 북마크 수 기준 내림차순 정렬(count) 구현.
- MyLinksPage / FolderCard: framer-motion 기반 카드 위치 변경 애니메이션 도입, 폴더명 폰트 크기 소폭 상향 및 미구현 '이동' 버튼 주석 처리.
- SortDropdown: 선택된 정렬 필터에 매핑되는 아이콘을 동적으로 출력하도록 개선.
- favicon.ts / RightPanel / SaveLinkDialog: 16x16 지구본 이미지 감지 시 구글 API -> 직접 탐색 -> 실패로 이어지는 3단계 폴백 고도화, 이미지 로딩 시 이니셜 페이드아웃 효과 추가 및 정렬 방향 역순 토글 기능 구현.

📖 참고 사항
- 북마크 수 정렬(count) 옵션의 정상 작동과 정렬 전환 시 카드가 부드럽게 교차 이동함을 확인하였습니다.

